### PR TITLE
New footO results layout draft (startTimes and Results) + elementary SEO meta tags

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 #VITE_API_DOMAIN=http://localhost/
 VITE_API_DOMAIN=https://www.oreplay.es/
-VITE_VERSION_NUMBER=0.2.1
+VITE_VERSION_NUMBER=0.2.2
 VITE_VERSION_TYPE=beta

--- a/index.html
+++ b/index.html
@@ -3,11 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/jpg" href="/logo.svg" />
+    <link rel="icon" type="image/x-icon" href="/logo.png">
+    <meta data-hid="image" itemprop="image" content="/logo.png">
+    <meta data-hid="og:image" property="og:image" content="/logo.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta data-hid="title" itemprop="title" content="O-Replay">
+    <meta data-hid="og:title" property="og:title" content="O-Replay">
+    <meta data-hid="og:site_name" property="og:site_name" content="O-Replay">
+    <meta data-hid="apple-mobile-web-app-title" name="apple-mobile-web-app-title" content="O-Replay">
+    <meta data-hid="language" name="language" content="en">
+    <meta data-hid="description" itemprop="description" content="O-Replay is the home to orienteering live results">
+    <meta data-hid="og:image:alt" property="og:image:alt" content="O-Replay is the home to orienteering live results">
+    <meta data-hid="og:description" property="og:description" content="O-Replay is the home to orienteering live results">
+    <meta data-hid="og:type" property="og:type" content="website">
     <title>O-Replay</title>
   </head>
   <body style="margin: 0; height:100vh">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <noscript>O-Replay is the home to orienteering live results</noscript>
   </body>
 </html>

--- a/public/locales/en-GB/translation.json
+++ b/public/locales/en-GB/translation.json
@@ -1,5 +1,6 @@
 {
   "Loading": "Loading...",
+  "ThisFunctionalityNotImplementedMsg": "This feature has not been implemented yet.",
   "Menu": "Menu",
   "Dates": "Dates",
   "Event": "Event",

--- a/public/locales/es-ES/translation.json
+++ b/public/locales/es-ES/translation.json
@@ -1,5 +1,6 @@
 {
   "Loading": "Cargando...",
+  "ThisFunctionalityNotImplementedMsg": "Esta funcionalidad aún no está disponible.",
   "Menu": "Menu",
   "Dates": "Fecha",
   "Event": "Evento",

--- a/public/locales/es-ES/translation.json
+++ b/public/locales/es-ES/translation.json
@@ -130,7 +130,7 @@
     "Position": "Posición",
     "Name": "Nombre",
     "Club": "Club",
-    "StartTime": "H.Salida",
+    "StartTime": "Salida",
     "FinishTime": "Tiempo",
     "Times": "Tiempos",
     "Points": "Puntos",

--- a/public/locales/fr-FR/translation.json
+++ b/public/locales/fr-FR/translation.json
@@ -1,5 +1,6 @@
 {
   "Loading": "Chargement...",
+  "ThisFunctionalityNotImplementedMsg": "_This feature has not been implemented yet.",
   "Menu": "_Menu",
   "Dates": "Dates",
   "Event": "Événement",

--- a/src/pages/Results/pages/EventDetail/EventDetail.tsx
+++ b/src/pages/Results/pages/EventDetail/EventDetail.tsx
@@ -1,12 +1,13 @@
-import {Box, Button, Typography} from "@mui/material";
+import {Box, Typography} from "@mui/material";
 import {Navigate, useNavigate, useParams} from "react-router-dom";
 import loadingIcon from "../../../../assets/loading.svg";
 import {useEffect, useState} from "react";
 import {getEventDetail} from "../../services/EventService.ts";
 import {useTranslation} from "react-i18next";
-import {ArrowForward, Launch} from "@mui/icons-material";
+import {ArrowForward} from "@mui/icons-material";
 import {EventDetailModel} from "../../../../shared/EntityTypes.ts";
 import {parseDate} from "../../../../shared/Functions.tsx";
+import EventDetailURLButton from "./components/EventDetailURLButton.tsx";
 
 export default function EventDetail() {
 
@@ -62,21 +63,6 @@ export default function EventDetail() {
     return null;
   }
 
-  function getButtonWebsite() {
-    if (detail?.website) {
-      return (
-        <Button style={styles.aligns} sx={{width: "min-content", marginTop: "12px", color: "white"}}
-          variant="contained"
-          onClick={() => {
-            window.open(detail?.website, '_blank', 'noopener,noreferrer')
-          }} endIcon={<Launch/>}>
-          {detail.website}
-        </Button>
-      )
-    }
-
-  }
-
   if (loadingData) {
     return (
       <Box sx={{
@@ -106,7 +92,7 @@ export default function EventDetail() {
         <Typography color={"secondary.main"}
           style={styles.titleEvent}>{detail?.description}</Typography>
         {getDatesOfEvent()}
-        {getButtonWebsite()}
+        <EventDetailURLButton url={detail?.website} marginLeft={styles.aligns.marginLeft} marginRight={styles.aligns.marginRight}/>
       </Box>
       <Box height={"100%"} sx={{
         bgcolor: "secondary.main",

--- a/src/pages/Results/pages/EventDetail/components/EventDetailURLButton.tsx
+++ b/src/pages/Results/pages/EventDetail/components/EventDetailURLButton.tsx
@@ -1,0 +1,59 @@
+import {Button} from "@mui/material";
+import {Launch} from "@mui/icons-material";
+import React from "react";
+
+
+interface MyComponentProps {
+  url: string|undefined,
+  marginLeft?:string,
+  marginRight?:string,
+}
+
+const EditeDetailURLButton: React.FC<MyComponentProps> = ({ url,marginLeft, marginRight }) => {
+
+  // Check if there is an URL
+  if (url) {
+    try {
+
+      // Check if protocol is missing (starts with `//` or does not contain `://`)
+      if (!/^https?:\/\//i.test(url)) {
+        url = 'https://' + url;
+      }
+
+      // Create URL object
+      const urlObject = new URL(url);
+
+      // return button
+      return (
+        <Button
+          style={{
+            "marginLeft": marginLeft,
+            "marginRight": marginRight
+          }}
+          sx={{
+            width: "min-content",
+            marginTop: "12px",
+            color: "white",
+            textTransform: "lowercase"
+          }}
+          variant="contained"
+          onClick={() => {
+            window.open(urlObject, '_blank', 'noopener,noreferrer')
+          }}
+          endIcon={<Launch/>}>
+          {urlObject.hostname}
+        </Button>
+      )
+
+      // if URL is invalid don't render anything
+    } catch {
+      return (<></>)
+    }
+
+  // if URL not provided don't render anything
+  } else {
+    return (<></>)
+  }
+}
+
+export default EditeDetailURLButton;

--- a/src/pages/Results/pages/FootO/components/ResultListContainer.tsx
+++ b/src/pages/Results/pages/FootO/components/ResultListContainer.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import {Box, Stack} from "@mui/material";
+
+interface ResultListContainerProps {
+  children: React.ReactNode
+}
+
+const ResultListContainer: React.FC<ResultListContainerProps> = ({children}) => {
+  return (
+    <Box sx={{height: "100%", marginBottom:'2rem', maxWidth:'600px'}}>
+      <Stack direction={"column"} spacing={2} sx={{flexWrap: 'wrap'}}>
+        {children}
+      </Stack>
+    </Box>
+  )
+}
+
+export default ResultListContainer;

--- a/src/pages/Results/pages/FootO/components/ResultListContainer.tsx
+++ b/src/pages/Results/pages/FootO/components/ResultListContainer.tsx
@@ -7,7 +7,7 @@ interface ResultListContainerProps {
 
 const ResultListContainer: React.FC<ResultListContainerProps> = ({children}) => {
   return (
-    <Box sx={{height: "100%", marginBottom:'2rem', maxWidth:'600px'}}>
+    <Box sx={{height: "100%", marginBottom:'2rem',marginTop:'1em', maxWidth:'600px', width:'100%'}}>
       <Stack direction={"column"} spacing={2} sx={{flexWrap: 'wrap'}}>
         {children}
       </Stack>

--- a/src/pages/Results/pages/FootO/components/ResultListItem.tsx
+++ b/src/pages/Results/pages/FootO/components/ResultListItem.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import {Box} from "@mui/material";
+
+interface ResultListItemProps {
+  children: React.ReactNode
+}
+
+const ResultListItem: React.FC<ResultListItemProps> = ({children,}) => {
+  return (
+    <Box
+      display="flex"
+      justifyContent="flex-start"
+      sx={{ flexDirection: 'row' }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default ResultListItem

--- a/src/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
+++ b/src/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
@@ -33,8 +33,9 @@ export default function FootOResults() {
                     display: "flex",          // Enables flex properties
                     flexDirection: "column",  // Stack content vertically
                     justifyContent: "flex-start",  // Align content to the top
+                    alignItems: "flex-end",
                     flexGrow: 1,
-                    width:'5px'
+                    width:'10px'
                   }}
                 >
                   <Typography sx={{color:'primary.main'}}>
@@ -48,7 +49,7 @@ export default function FootOResults() {
                     flexDirection: 'column',
                     justifyContent: 'space-between',
                     width:'100%',
-                    marginLeft:'1em'
+                    marginLeft:'.3em'
                   }}
                 >
                   <Box>

--- a/src/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
+++ b/src/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
@@ -1,32 +1,14 @@
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography
-} from "@mui/material";
-import {useContext, useEffect, useState} from "react";
+import {useContext} from "react";
 import {useTranslation} from "react-i18next";
-import {parseDateOnlyTime, parseSecondsToMMSS} from "../../../../../../shared/Functions.tsx";
 import {RunnersContext} from "../../../../shared/context.ts";
-import {parseResultStatus} from "../../../../shared/functions.ts";
+import ResultListContainer from "../../components/ResultListContainer.tsx";
+import {RunnerModel} from "../../../../../../shared/EntityTypes.ts";
+import ResultListItem from "../../components/ResultListItem.tsx";
+import {Box, Typography} from "@mui/material";
+import {parseSecondsToMMSS, parseStartTime} from "../../../../../../shared/Functions.tsx";
 
 export default function FootOResults() {
-  const [widthWindow, setWidthWindow] = useState<number>(0);
   const {t} = useTranslation();
-
-  const handleWindowSizeChange = () => {
-    setWidthWindow(window.innerWidth);
-  };
-
-  useEffect(() => {
-    window.addEventListener('resize', handleWindowSizeChange);
-    return () => {
-      window.removeEventListener('resize', handleWindowSizeChange);
-    }
-  }, [])
 
   const [runnersList,isLoading] = useContext(RunnersContext)
 
@@ -35,61 +17,80 @@ export default function FootOResults() {
     return (<p>{t('Loading')}</p>)
   } else {
     return (
-      <TableContainer sx={{height: '100%', flex: 1, position: 'absolute'}}>
-        <Table stickyHeader>
-          <TableHead>
-            <TableRow key={"table Head"}>
-              <TableCell></TableCell>
-              <TableCell sx={{fontWeight: "bold"}}>{t('ResultsStage.Name')}</TableCell>
-              {widthWindow > 768 ? (
-                <TableCell sx={{fontWeight: "bold"}}>{t('ResultsStage.Club')}</TableCell>
-              ) : null}
-              {widthWindow > 768 ? (
-                <TableCell sx={{fontWeight: "bold"}}>{t('ResultsStage.StartTime')}</TableCell>
-              ) : <TableCell sx={{fontWeight: "bold"}}>{t('ResultsStage.Times')}</TableCell>}
-              {widthWindow > 768 ? (
-                <TableCell sx={{fontWeight: "bold"}}>{t('ResultsStage.FinishTime')}</TableCell>
-              ) : null}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {runnersList?.map((runner) => {
-
-              const status = parseResultStatus(runner.runner_results[0].status_code as string)
-
-              return (
-                <TableRow sx={{width: {md: "100%", sx: "200px"}}} key={runner.id}>
-                  <TableCell key={`${runner.id}`}>{(status==="ok")? runner.runner_results[0].position.toString() : ""}</TableCell>
-                  {widthWindow > 768 ? (
-                    <TableCell>{runner.first_name} {runner.last_name}</TableCell>
-                  ) :
-                    <TableCell sx={{maxWidth: "180px"}}>
-                      <Typography>{runner.first_name}</Typography>
-                      <Typography>{runner.last_name}</Typography>
-                      <br></br>
-                      <Typography sx={{color:'text.secondary'}}>{runner.club.short_name}</Typography>
-                    </TableCell>}
-
-                  {widthWindow > 768 ? (
-                    <TableCell><Typography>{runner.club.short_name}</Typography></TableCell>
-                  ) : null}
-                  {widthWindow > 768 ? (
-                    <TableCell>{parseDateOnlyTime(runner.runner_results[0].start_time)}</TableCell>
-                  ) :
-                    <TableCell>
-                      <Typography>{parseDateOnlyTime(runner.runner_results[0].start_time)}</Typography>
-                      <br></br>
-                      <Typography>{(status==="ok")? (runner.runner_results[0].finish_time != null ? parseSecondsToMMSS(runner.runner_results[0].time_seconds) : "") : t(`ResultsStage.statusCodes.${status}`) }</Typography>
-                    </TableCell>}
-                  {widthWindow > 768 ? (
-                    <TableCell>{(status==="ok")? (runner.runner_results[0].finish_time != null ? parseSecondsToMMSS(runner.runner_results[0].time_seconds) : "") : t(`ResultsStage.statusCodes.${status}`)}</TableCell>
-                  ) : null}
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <ResultListContainer>
+        {
+          runnersList.map((runner: RunnerModel) => (
+            <ResultListItem
+              key={runner.id}
+            >
+              <Box
+                sx={{
+                  flexShrink: 0,
+                  display: "flex",          // Enables flex properties
+                  flexDirection: "column",  // Stack content vertically
+                  justifyContent: "flex-start",  // Align content to the top
+                  flexGrow: 1,
+                }}
+              >
+                <Typography sx={{color:'primary.main'}}>
+                  {`${runner.runner_results[0].position}.`}
+                </Typography>
+              </Box>
+              <Box
+                sx={{
+                  display:'flex',
+                  flexShrink: 1,
+                  flexDirection: 'column',
+                  justifyContent: 'space-between',
+                  width:'100%',
+                  marginLeft:'1em'
+                }}
+              >
+                <Box>
+                  <Typography>
+                    {`${runner.first_name} ${runner.last_name}`}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      color:'text.secondary'
+                    }}
+                  >
+                    {`${runner.club.short_name}`}
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: "space-between",
+                    width: '100%'
+                  }}
+                >
+                  <Box sx={{
+                    display:'inline-flex',
+                    flexDirection:'row',
+                    justifyContent:'space-between',
+                    gap:'.3em'
+                  }}>
+                    <Typography sx={{color:'secondary.main'}}>{`${t('ResultsStage.StartTime')}:`}</Typography>
+                    <Typography>{parseStartTime(runner.runner_results[0].start_time)}</Typography>
+                  </Box>
+                  <Box sx={{
+                    display:'inline-flex',
+                    flexDirection:'row',
+                    justifyContent:'space-between',
+                    gap:'.3em'
+                  }}>
+                    <Typography sx={{color:'secondary.main'}}>{`${t('ResultsStage.FinishTime')}:`}</Typography>
+                    <Typography>{parseSecondsToMMSS(runner.runner_results[0].time_seconds)}</Typography>
+                    <Typography sx={{color:'primary.main'}}>{`+${parseSecondsToMMSS(runner.runner_results[0].time_behind.toString())}`}</Typography>
+                  </Box>
+                </Box>
+              </Box>
+            </ResultListItem>
+          ))
+        }
+      </ResultListContainer>
     )
   }
 }

--- a/src/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
+++ b/src/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
@@ -6,6 +6,7 @@ import {RunnerModel} from "../../../../../../shared/EntityTypes.ts";
 import ResultListItem from "../../components/ResultListItem.tsx";
 import {Box, Typography} from "@mui/material";
 import {parseSecondsToMMSS, parseStartTime} from "../../../../../../shared/Functions.tsx";
+import {parseResultStatus} from "../../../../shared/functions.ts";
 
 export default function FootOResults() {
   const {t} = useTranslation();
@@ -19,76 +20,89 @@ export default function FootOResults() {
     return (
       <ResultListContainer>
         {
-          runnersList.map((runner: RunnerModel) => (
-            <ResultListItem
-              key={runner.id}
-            >
-              <Box
-                sx={{
-                  flexShrink: 0,
-                  display: "flex",          // Enables flex properties
-                  flexDirection: "column",  // Stack content vertically
-                  justifyContent: "flex-start",  // Align content to the top
-                  flexGrow: 1,
-                }}
+          runnersList.map((runner: RunnerModel) => {
+            const status = parseResultStatus(runner.runner_results[0].status_code as string)
+
+            return (
+              <ResultListItem
+                key={runner.id}
               >
-                <Typography sx={{color:'primary.main'}}>
-                  {`${runner.runner_results[0].position}.`}
-                </Typography>
-              </Box>
-              <Box
-                sx={{
-                  display:'flex',
-                  flexShrink: 1,
-                  flexDirection: 'column',
-                  justifyContent: 'space-between',
-                  width:'100%',
-                  marginLeft:'1em'
-                }}
-              >
-                <Box>
-                  <Typography>
-                    {`${runner.first_name} ${runner.last_name}`}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      color:'text.secondary'
-                    }}
-                  >
-                    {`${runner.club.short_name}`}
+                <Box
+                  sx={{
+                    flexShrink: 0,
+                    display: "flex",          // Enables flex properties
+                    flexDirection: "column",  // Stack content vertically
+                    justifyContent: "flex-start",  // Align content to the top
+                    flexGrow: 1,
+                    width:'5px'
+                  }}
+                >
+                  <Typography sx={{color:'primary.main'}}>
+                    {runner.runner_results[0].position ? `${runner.runner_results[0].position}.` : ''}
                   </Typography>
                 </Box>
                 <Box
                   sx={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: "space-between",
-                    width: '100%'
+                    display:'flex',
+                    flexShrink: 1,
+                    flexDirection: 'column',
+                    justifyContent: 'space-between',
+                    width:'100%',
+                    marginLeft:'1em'
                   }}
                 >
-                  <Box sx={{
-                    display:'inline-flex',
-                    flexDirection:'row',
-                    justifyContent:'space-between',
-                    gap:'.3em'
-                  }}>
-                    <Typography sx={{color:'secondary.main'}}>{`${t('ResultsStage.StartTime')}:`}</Typography>
-                    <Typography>{parseStartTime(runner.runner_results[0].start_time)}</Typography>
+                  <Box>
+                    <Typography>
+                      {`${runner.first_name} ${runner.last_name}`}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        color:'text.secondary'
+                      }}
+                    >
+                      {`${runner.club.short_name}`}
+                    </Typography>
                   </Box>
-                  <Box sx={{
-                    display:'inline-flex',
-                    flexDirection:'row',
-                    justifyContent:'space-between',
-                    gap:'.3em'
-                  }}>
-                    <Typography sx={{color:'secondary.main'}}>{`${t('ResultsStage.FinishTime')}:`}</Typography>
-                    <Typography>{parseSecondsToMMSS(runner.runner_results[0].time_seconds)}</Typography>
-                    <Typography sx={{color:'primary.main'}}>{`+${parseSecondsToMMSS(runner.runner_results[0].time_behind.toString())}`}</Typography>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                      justifyContent: "space-between",
+                      width: '100%'
+                    }}
+                  >
+                    <Box sx={{
+                      display:'inline-flex',
+                      flexDirection:'row',
+                      justifyContent:'space-between',
+                      gap:'.1em'
+                    }}>
+                      <Typography sx={{color:'secondary.main'}}>{`${t('ResultsStage.StartTime')}:`}</Typography>
+                      <Typography>{parseStartTime(runner.runner_results[0].start_time)}</Typography>
+                    </Box>
+                    <Box sx={{
+                      display:'inline-flex',
+                      flexDirection:'row',
+                      justifyContent:'flex-start',
+                      gap:'.15em',
+                    }}>
+                      <Typography sx={{color:'secondary.main'}}>{`${t('ResultsStage.FinishTime')}:`}</Typography>
+                      <Typography>{(status==="ok")? (runner.runner_results[0].finish_time != null ? parseSecondsToMMSS(runner.runner_results[0].time_seconds) : "-") : t(`ResultsStage.statusCodes.${status}`) }</Typography>
+                      <Typography sx={{color:'primary.main'}}>
+                        {
+                          ((status==="ok")&&(runner.runner_results[0].finish_time != null))
+                            ?
+                          `+${parseSecondsToMMSS(runner.runner_results[0].time_behind.toString())}`
+                            :
+                            ""
+                        }
+                      </Typography>
+                    </Box>
                   </Box>
                 </Box>
-              </Box>
-            </ResultListItem>
-          ))
+              </ResultListItem>
+            )
+          })
         }
       </ResultListContainer>
     )

--- a/src/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
+++ b/src/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
@@ -1,9 +1,15 @@
-import {Box} from "@mui/material";
+
+import ResultListContainer from "../../components/ResultListContainer.tsx";
+import {Alert} from "@mui/material";
+import ScienceIcon from "@mui/icons-material/Science";
+import {useTranslation} from "react-i18next";
 
 export default function FootOSplits() {
+  const {t} = useTranslation();
+
   return (
-    <Box sx={{height: "100%", padding: "24px 48px"}}>
-      SPLITS
-    </Box>
+    <ResultListContainer>
+      <Alert icon={<ScienceIcon />} severity="info">{t('ThisFunctionalityNotImplementedMsg')}</Alert>
+    </ResultListContainer>
   )
 }

--- a/src/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
+++ b/src/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
@@ -5,6 +5,8 @@ import {RunnerModel} from "../../../../../../shared/EntityTypes.ts";
 import {orderRunnersByStartTime} from "./shared/functions.ts";
 import {useTranslation} from "react-i18next";
 import {parseStartTime} from "../../../../../../shared/Functions.tsx";
+import ResultListContainer from "../../components/ResultListContainer.tsx";
+import ResultListItem from "../../components/ResultListItem.tsx";
 
 export default function FootOStartTime() {
   const {t} = useTranslation()
@@ -22,54 +24,46 @@ export default function FootOStartTime() {
     return t('Loading')
   } else {
     return (
-      <Box sx={{height: "100%", marginBottom:'2rem', maxWidth:'600px'}}>
-        <Stack direction={"column"} spacing={2} sx={{flexWrap: 'wrap'}}>
-          {
-            runnersByStartTime.map((runner) => (
+      <ResultListContainer>
+        {
+          runnersByStartTime.map((runner) => (
+            <ResultListItem key={runner.id}>
               <Box
-                key={runner.id}
-                display="flex"
-                alignItems="center"
-                justifyContent="space-between"
-                sx={{ flexDirection: 'row' }}
+                sx={{
+                  flexGrow: 1,  // Make this element flexible
+                  flexShrink: 1,  // Allow shrinking if needed
+                  flexBasis: 0,  // Allow it to take as much space as needed
+                  overflowWrap: 'break-word',  // Allow text to wrap
+                  wordBreak: 'break-word',  // Break long words to fit
+                }}
               >
-                <Box
-                  sx={{
-                    flexGrow: 1,  // Make this element flexible
-                    flexShrink: 1,  // Allow shrinking if needed
-                    flexBasis: 0,  // Allow it to take as much space as needed
-                    overflowWrap: 'break-word',  // Allow text to wrap
-                    wordBreak: 'break-word',  // Break long words to fit
-                  }}
-                >
-                  <Stack direction={'column'}>
-                    <Typography>
-                      {`${runner.first_name} ${runner.last_name}`}
-                    </Typography>
-                    <Typography sx={{color:'text.secondary'}}>
-                      {`${runner.club.short_name}`}
-                    </Typography>
-                  </Stack>
-                </Box>
-                <Box
-                  sx={{
-                    flexShrink: 0,
-                    display: "flex", // Add this line to enable flex properties for the box
-                    flexDirection: "column", // Stack text vertically
-                    alignItems: "center", // Center the content horizontally in the box
-                    justifyContent: "center", // Center the content vertically in the box
-                    textAlign: "center", // Center the text itself inside each Typography component
-                  }}
-                >
-                  <Typography>{parseStartTime(runner.runner_results[0].start_time)}</Typography>
-                  <Typography sx={{color:'text.secondary'}}>{`${runner.sicard}`}</Typography>
-                </Box>
+                <Stack direction={'column'}>
+                  <Typography>
+                    {`${runner.first_name} ${runner.last_name}`}
+                  </Typography>
+                  <Typography sx={{color:'text.secondary'}}>
+                    {`${runner.club.short_name}`}
+                  </Typography>
+                </Stack>
               </Box>
-            )
-            )
-          }
-        </Stack>
-      </Box>
+              <Box
+                sx={{
+                  flexShrink: 0,
+                  display: "flex", // Add this line to enable flex properties for the box
+                  flexDirection: "column", // Stack text vertically
+                  alignItems: "center", // Center the content horizontally in the box
+                  justifyContent: "center", // Center the content vertically in the box
+                  textAlign: "center", // Center the text itself inside each Typography component
+                }}
+              >
+                <Typography>{parseStartTime(runner.runner_results[0].start_time)}</Typography>
+                <Typography sx={{color:'text.secondary'}}>{`${runner.sicard}`}</Typography>
+              </Box>
+            </ResultListItem>
+          )
+          )
+        }
+      </ResultListContainer>
     )
   }
 }

--- a/src/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
+++ b/src/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
@@ -1,9 +1,75 @@
-import {Box} from "@mui/material";
+import {Box, Stack, Typography} from "@mui/material";
+import {useContext, useEffect, useState} from "react";
+import {RunnersContext} from "../../../../shared/context.ts";
+import {RunnerModel} from "../../../../../../shared/EntityTypes.ts";
+import {orderRunnersByStartTime} from "./shared/functions.ts";
+import {useTranslation} from "react-i18next";
+import {parseStartTime} from "../../../../../../shared/Functions.tsx";
 
 export default function FootOStartTime() {
-  return (
-    <Box sx={{height: "100%", padding: "24px 48px"}}>
-      START TIMES
-    </Box>
-  )
+  const {t} = useTranslation()
+
+  // Get runners and order by start time
+  const [rawRunnersList,isLoading] = useContext(RunnersContext)
+  const [runnersByStartTime,setRunnersByStartTime] = useState<RunnerModel[]>(rawRunnersList)
+
+  useEffect(() => {
+    setRunnersByStartTime( orderRunnersByStartTime(rawRunnersList) )
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runnersByStartTime]);
+
+  if (isLoading) {
+    return t('Loading')
+  } else {
+    return (
+      <Box sx={{height: "100%", marginBottom:'2rem', maxWidth:'600px'}}>
+        <Stack direction={"column"} spacing={2} sx={{flexWrap: 'wrap'}}>
+          {
+            runnersByStartTime.map((runner) => (
+              <Box
+                key={runner.id}
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ flexDirection: 'row' }}
+              >
+                <Box
+                  sx={{
+                    flexGrow: 1,  // Make this element flexible
+                    flexShrink: 1,  // Allow shrinking if needed
+                    flexBasis: 0,  // Allow it to take as much space as needed
+                    overflowWrap: 'break-word',  // Allow text to wrap
+                    wordBreak: 'break-word',  // Break long words to fit
+                  }}
+                >
+                  <Stack direction={'column'}>
+                    <Typography>
+                      {`${runner.first_name} ${runner.last_name}`}
+                    </Typography>
+                    <Typography sx={{color:'text.secondary'}}>
+                      {`${runner.club.short_name}`}
+                    </Typography>
+                  </Stack>
+                </Box>
+                <Box
+                  sx={{
+                    flexShrink: 0,
+                    display: "flex", // Add this line to enable flex properties for the box
+                    flexDirection: "column", // Stack text vertically
+                    alignItems: "center", // Center the content horizontally in the box
+                    justifyContent: "center", // Center the content vertically in the box
+                    textAlign: "center", // Center the text itself inside each Typography component
+                  }}
+                >
+                  <Typography>{parseStartTime(runner.runner_results[0].start_time)}</Typography>
+                  <Typography sx={{color:'text.secondary'}}>{`${runner.sicard}`}</Typography>
+                </Box>
+              </Box>
+            )
+            )
+          }
+        </Stack>
+      </Box>
+    )
+  }
 }

--- a/src/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
+++ b/src/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
@@ -17,8 +17,7 @@ export default function FootOStartTime() {
 
   useEffect(() => {
     setRunnersByStartTime( orderRunnersByStartTime(rawRunnersList) )
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runnersByStartTime]);
+  }, [rawRunnersList]);
 
   if (isLoading) {
     return t('Loading')

--- a/src/pages/Results/pages/FootO/pages/StartTime/shared/functions.ts
+++ b/src/pages/Results/pages/FootO/pages/StartTime/shared/functions.ts
@@ -1,0 +1,11 @@
+import {RunnerModel} from "../../../../../../../shared/EntityTypes.ts";
+
+export function orderRunnersByStartTime (runnersList:RunnerModel[]):RunnerModel[] {
+
+  return runnersList.sort((a, b) => {
+    const dateA = new Date(a.runner_results[0]?.start_time).getTime();
+    const dateB = new Date(b.runner_results[0]?.start_time).getTime();
+
+    return dateA - dateB; // Compare timestamps
+  });
+}

--- a/src/pages/Results/pages/FootO/pages/StartTime/shared/functions.ts
+++ b/src/pages/Results/pages/FootO/pages/StartTime/shared/functions.ts
@@ -1,8 +1,14 @@
 import {RunnerModel} from "../../../../../../../shared/EntityTypes.ts";
 
+/**
+ * This function orders runners in a class by their start times. The original
+ * array is copied to avoid its mutation.
+ * @param runnersList A list of runners to be ordered
+ */
 export function orderRunnersByStartTime (runnersList:RunnerModel[]):RunnerModel[] {
 
-  return runnersList.sort((a, b) => {
+  // a shallow copy is made first to avoid mutating the original data
+  return [...runnersList].sort((a, b) => {
     const dateA = new Date(a.runner_results[0]?.start_time).getTime();
     const dateB = new Date(b.runner_results[0]?.start_time).getTime();
 

--- a/src/pages/Results/pages/components/EventStageBanner.tsx
+++ b/src/pages/Results/pages/components/EventStageBanner.tsx
@@ -13,7 +13,7 @@ export default function EventStageBanner(props:EventStageBannerProps) {
       sx={{
         fontWeight: "bold",
         paddingY: "1em", // Add left padding for a consistent margin
-        paddingX: '48px',
+        paddingX: '24px',
         backgroundColor: '#efefef',
         textAlign: "left" // Ensure all text within this Box is left-aligned
       }}

--- a/src/pages/Results/pages/components/StageLayout.tsx
+++ b/src/pages/Results/pages/components/StageLayout.tsx
@@ -110,7 +110,7 @@ export default function StageLayout () {
         <EventStageBanner eventName={eventName} stageName={stageName} singleStage={singleStage} />
         <Box sx={{
           height: "calc(100% - 64px)",
-          padding: "24px 48px",
+          padding: "24px 24px",
           display: 'flex',
           flexDirection: 'column',
           minHeight: 0

--- a/src/shared/Functions.tsx
+++ b/src/shared/Functions.tsx
@@ -22,6 +22,11 @@ export function parseDateOnlyTime(dateString: string)
   return parseLuxon(dateString).toLocaleString(DateTime.TIME_24_SIMPLE);
 }
 
+export function parseStartTime(dateString: string)
+{
+  return parseLuxon(dateString).toFormat('HH:mm:ss');
+}
+
 export function parseSecondsToMMSS(seconds: number|string) {
   const duration = DateTime.fromSeconds(Number(seconds)).toUTC();
   const oneHour = 3600


### PR DESCRIPTION
Changes:
  - New layout components `ResultListContainer` and `ResultListItem` are created. The are intended to be the base of mobile view.
  - A completely new start time page is created for FootO
  - The FootO results screen is rebuild from scratch using the new components mentioned above
  - Some elementary `<meta>` tags are added to provide info to web scrawlers.

Some important TODOs:
  - Implement a final way to check phone or desktop versions
  - Implement a splits page for FootO