### PR TITLE
New club-based result views

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -148,9 +148,11 @@
     "NoStartTime": "-",
     "NotStarted": "-",
     "Class": "Class",
+    "Classes": "Classes",
     "Position": "Position",
     "Name": "Name",
     "Club": "Club",
+    "Clubs": "Clubs",
     "NoClubMsg": "No club",
     "StartTime": "Start",
     "RaceTime": "Time",
@@ -181,7 +183,11 @@
     "SplitsTable": {
       "NoRunnersWithSplits": "No runner has downloaded their chip",
       "PartialTimes": "Partials",
-      "CumulativeTimes": "Cumulative"
+      "CumulativeTimes": "Cumulative",
+      "OnlyForClasses": "Splits table is accessible only in the class-based view."
+    },
+    "PointsTable": {
+      "OnlyForClasses": "Points view is accessible only in the class-based view."
     },
     "WrongFileUploaded": {
       "Title": "Results Without Splits!",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,5 +1,9 @@
 {
   "Loading": "Loading...",
+  "Search": {
+    "Search": "Search",
+    "ClearSearch": "Clear search"
+  },
   "GeneralErrorFallback": {
     "title": "An unexpected error happened",
     "msg": "Try refreshing the page. If the error persist, please try again later."

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -151,6 +151,8 @@
     "Position": "Posición",
     "Name": "Nombre",
     "Club": "Club",
+    "Clubs": "Clubs",
+    "Classes": "Categorías",
     "NoClubMsg": "Sin club",
     "StartTime": "Salida",
     "FinishTime": "Tiempo",
@@ -181,7 +183,11 @@
     "SplitsTable": {
       "NoRunnersWithSplits": "Ningún corredor ha descargado su chip",
       "PartialTimes": "Parciales",
-      "CumulativeTimes": "Acumulados"
+      "CumulativeTimes": "Acumulados",
+      "OnlyForClasses": "La tabla de parciales solo está disponible para resultados por categorías."
+    },
+    "PointsTable": {
+      "OnlyForClasses": "El visor de puntos solo está disponible para resultados por categorías"
     },
     "WrongFileUploaded": {
       "Title": "¡Resultados Sin Parciales!",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,5 +1,9 @@
 {
   "Loading": "Cargando...",
+  "Search": {
+    "Search": "Buscar",
+    "ClearSearch": "Limpiar búsqueda"
+  },
   "GeneralErrorFallback": {
     "title": "Ha ocurrido un error inesperado",
     "msg": "Pruebe a refrescar la página. Si el error persiste inténtelo de nuevo más tarde"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -148,9 +148,11 @@
     "NoStartTime": "-",
     "NotStarted": "-",
     "Class": "Class",
+    "Classes": "Classes",
     "Position": "Position",
     "Name": "Nom",
     "Club": "Club",
+    "Clubs": "_Clubs",
     "NoClubMsg": "No club",
     "StartTime": "Départ",
     "RaceTime": "Temp",
@@ -181,7 +183,11 @@
     "SplitsTable": {
       "NoRunnersWithSplits": ":No runner has downloaded their chip.",
       "PartialTimes": "_Partials",
-      "CumulativeTimes": "_Cumulative"
+      "CumulativeTimes": "_Cumulative",
+      "OnlyForClasses": "_Splits table is accessible only in the class-based view."
+    },
+    "PointsTable": {
+      "OnlyForClasses": "_Points view is accessible only in the class-based view."
     },
     "WrongFileUploaded": {
       "Title": "_Results Without Splits!",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,5 +1,9 @@
 {
   "Loading": "Chargement...",
+  "Search": {
+    "Search": "_Search",
+    "ClearSearch": "_Clear search"
+  },
   "GeneralErrorFallback": {
     "title": "_An unexpected error happened",
     "msg": "_Try refreshing the page. If the error persist, please try again later."

--- a/src/components/ListSkeleton/ListSkeleton.tsx
+++ b/src/components/ListSkeleton/ListSkeleton.tsx
@@ -6,9 +6,16 @@ interface ListSkeletonProps {
   gap: string
   style?: CSSProperties
   className?: string
+  minItems?: number
 }
 
-export default function ListSkeleton({ SkeletonItem, style, className, gap }: ListSkeletonProps) {
+export default function ListSkeleton({
+  SkeletonItem,
+  style,
+  className,
+  gap,
+  minItems,
+}: ListSkeletonProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const skeletonRef = useRef<HTMLDivElement>(null)
   const [skeletonHeight, setSkeletonHeight] = useState<number | null>(null)
@@ -35,15 +42,19 @@ export default function ListSkeleton({ SkeletonItem, style, className, gap }: Li
   useEffect(() => {
     if (skeletonHeight && containerRef.current) {
       const containerHeight = containerRef.current.clientHeight
-      const count = Math.floor(containerHeight / skeletonHeight)
+      let count = Math.floor(containerHeight / skeletonHeight)
+      if (minItems && count < Math.floor(minItems)) {
+        count = minItems
+      }
+
       setSkeletonCount(count)
     }
-  }, [skeletonHeight])
+  }, [minItems, skeletonHeight])
 
   return (
     <Stack
       ref={containerRef}
-      style={{ height: "100%", overflow: "hidden", ...style }}
+      style={{ height: "100%", width: "100%", overflow: "hidden", ...style }}
       className={className}
       direction="column"
       gap={gap}

--- a/src/components/ListSkeleton/ListSkeleton.tsx
+++ b/src/components/ListSkeleton/ListSkeleton.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState, ComponentType, CSSProperties } from "react"
+import { Stack } from "@mui/material"
+
+interface ListSkeletonProps {
+  SkeletonItem: ComponentType
+  gap: string
+  style?: CSSProperties
+  className?: string
+}
+
+export default function ListSkeleton({ SkeletonItem, style, className, gap }: ListSkeletonProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const skeletonRef = useRef<HTMLDivElement>(null)
+  const [skeletonHeight, setSkeletonHeight] = useState<number | null>(null)
+  const [skeletonCount, setSkeletonCount] = useState(0)
+
+  // Measure the skeleton item height
+  useEffect(() => {
+    if (!skeletonRef.current) return
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (entry.contentRect.height > 0) {
+        setSkeletonHeight(entry.contentRect.height)
+      }
+    })
+
+    resizeObserver.observe(skeletonRef.current)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [])
+
+  // Once we have the height, calculate how many fit
+  useEffect(() => {
+    if (skeletonHeight && containerRef.current) {
+      const containerHeight = containerRef.current.clientHeight
+      console.log("ContainerHeight", containerHeight)
+      const count = Math.floor(containerHeight / skeletonHeight)
+      setSkeletonCount(count)
+    }
+  }, [skeletonHeight])
+
+  return (
+    <Stack
+      ref={containerRef}
+      style={{ height: "100%", overflow: "hidden", ...style }}
+      className={className}
+      direction="column"
+      gap={gap}
+    >
+      {/* Render one item offscreen just to measure height */}
+      {!skeletonHeight && (
+        <div ref={skeletonRef} style={{ visibility: "hidden", position: "absolute" }}>
+          <SkeletonItem />
+        </div>
+      )}
+
+      {/* Render full list once height is known */}
+      {skeletonHeight &&
+        Array.from({ length: skeletonCount }).map((_, index) => <SkeletonItem key={index} />)}
+    </Stack>
+  )
+}

--- a/src/components/ListSkeleton/ListSkeleton.tsx
+++ b/src/components/ListSkeleton/ListSkeleton.tsx
@@ -35,7 +35,6 @@ export default function ListSkeleton({ SkeletonItem, style, className, gap }: Li
   useEffect(() => {
     if (skeletonHeight && containerRef.current) {
       const containerHeight = containerRef.current.clientHeight
-      console.log("ContainerHeight", containerHeight)
       const count = Math.floor(containerHeight / skeletonHeight)
       setSkeletonCount(count)
     }

--- a/src/domain/services/RunnerService.ts
+++ b/src/domain/services/RunnerService.ts
@@ -14,7 +14,12 @@ const compareLegNumber = (a: RunnerModel, b: RunnerModel): number => {
   return (a?.overall?.leg_number || 0) - (b?.overall?.leg_number || 0)
 }
 
+const getClassName = (runner: ProcessedRunnerModel) => {
+  return runner.class.short_name
+}
+
 export const runnerService = {
   getClubName,
+  getClassName,
   compareLegNumber,
 }

--- a/src/pages/Results/components/VirtualTicket/VirtualTicketContainer.tsx
+++ b/src/pages/Results/components/VirtualTicket/VirtualTicketContainer.tsx
@@ -4,7 +4,7 @@ import CloseIcon from "@mui/icons-material/Close"
 import { ProcessedRunnerModel } from "./shared/EntityTypes.ts"
 import ExperimentalFeatureAlert from "../../../../components/ExperimentalFeatureAlert.tsx"
 
-export type VirtualTicketProps = {
+export interface VirtualTicketProps {
   isTicketOpen: boolean
   runner: ProcessedRunnerModel | null
   handleCloseTicket: () => void

--- a/src/pages/Results/components/VirtualTicket/shared/virtualTicketFunctions.ts
+++ b/src/pages/Results/components/VirtualTicket/shared/virtualTicketFunctions.ts
@@ -5,7 +5,6 @@ import {
   ProcessedRunnerResultModel,
   ProcessedSplitModel,
 } from "./EntityTypes.ts"
-import { orderedRunners } from "../../../shared/functions.ts"
 import { DateTime } from "luxon"
 import { hasChipDownload, isRunnerNC } from "../../../pages/Results/shared/functions.ts"
 import { getCourseFromRunner } from "../../../pages/Results/pages/FootO/pages/Splits/components/FootOSplitsTable/shared/footOSplitsTablefunctions.ts"
@@ -18,8 +17,6 @@ import { getCourseFromRunner } from "../../../pages/Results/pages/FootO/pages/Sp
  * @param runners runners to process
  */
 export function processRunnerData(runners: RunnerModel[]): ProcessedRunnerModel[] {
-  runners = orderedRunners(runners)
-
   return runners.map((runner): ProcessedRunnerModel => {
     const runnerResults = []
     runnerResults.push(runner.overall) // TODO refactor

--- a/src/pages/Results/pages/Results/components/Layout/StageLayout.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/StageLayout.tsx
@@ -3,19 +3,21 @@ import ClassSelector from "./components/ClassSelector.tsx"
 import Tooltip from "@mui/material/Tooltip"
 import RefreshIcon from "@mui/icons-material/Refresh"
 import { useTranslation } from "react-i18next"
-import { ClassModel } from "../../../../../../shared/EntityTypes.ts"
+import { ClassModel, ClubModel, Page } from "../../../../../../shared/EntityTypes.ts"
 import React from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import GeneralErrorFallback from "../../../../../../components/GeneralErrorFallback.tsx"
-import NoDataInStageMsg from "../NoDataInStageMsg.tsx"
+//import NoDataInStageMsg from "../NoDataInStageMsg.tsx"
 import WrongResultsFileUploadedMsg from "../WrongResultsFileUploadedMsg.tsx"
+import { UseQueryResult } from "react-query"
 
 type StageLayoutProps = {
   handleRefreshClick: () => void
-  classesList: ClassModel[]
-  setActiveClassId: (newActiveClassId: string) => void
-  activeClass: ClassModel | null
-  areClassesLoading: boolean
+  isClass: boolean
+  classesQuery: UseQueryResult<Page<ClassModel>>
+  clubsQuery: UseQueryResult<Page<ClubModel>>
+  setActiveClassClub: (newActiveClassId: string, isClass: boolean) => void
+  activeItem: ClassModel | ClubModel | null
   isWrongFileUploaded?: boolean
   children: React.ReactNode
 }
@@ -23,9 +25,9 @@ type StageLayoutProps = {
 export default function StageLayout(props: StageLayoutProps) {
   const { t } = useTranslation()
 
-  if (props.classesList.length === 0 && !props.areClassesLoading) {
-    return <NoDataInStageMsg />
-  }
+  //if (props.classesList.length === 0 && !props.areClassesLoading) {
+  //  return <NoDataInStageMsg />
+  //}
 
   return (
     <Box
@@ -48,10 +50,11 @@ export default function StageLayout(props: StageLayoutProps) {
         }}
       >
         <ClassSelector
-          activeClass={props.activeClass}
-          setActiveClassId={props.setActiveClassId}
-          classesList={props.classesList}
-          isLoading={props.areClassesLoading}
+          activeClassClub={props.activeItem}
+          isClass={props.isClass}
+          setActiveClassClubId={props.setActiveClassClub}
+          classesQuery={props.classesQuery}
+          clubsQuery={props.clubsQuery}
         />
         <Tooltip title={t("ResultsStage.Refresh")}>
           <IconButton onClick={props.handleRefreshClick}>

--- a/src/pages/Results/pages/Results/components/Layout/StageLayout.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/StageLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton } from "@mui/material"
-import ClassSelector from "./components/ClassSelector.tsx"
+import ClassSelector from "./components/ClassSelector/ClassSelector.tsx"
 import Tooltip from "@mui/material/Tooltip"
 import RefreshIcon from "@mui/icons-material/Refresh"
 import { useTranslation } from "react-i18next"

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Dialog,
   DialogContent,
-  DialogTitle,
   FormControl,
   InputAdornment,
   InputLabel,
@@ -10,26 +9,60 @@ import {
   ListItemButton,
   ListItemText,
   OutlinedInput,
+  Tab,
+  Tabs,
 } from "@mui/material"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import { useTranslation } from "react-i18next"
-import { ClassModel } from "../../../../../../../shared/EntityTypes.ts"
-import { useState } from "react"
+import { ClassModel, ClubModel, Page } from "../../../../../../../shared/EntityTypes.ts"
+import { ReactNode, useState } from "react"
+import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined"
+import LeaderboardOutlinedIcon from "@mui/icons-material/LeaderboardOutlined"
+import { UseQueryResult } from "react-query"
 
 interface ClassSelectorProps {
-  activeClass: ClassModel | null
-  setActiveClassId: (newActiveClassId: string) => void
-  classesList: ClassModel[]
-  isLoading: boolean
+  isClass: boolean
+  activeClassClub: ClassModel | ClubModel | null
+  setActiveClassClubId: (newActiveClassId: string, isClass: boolean) => void
+  classesQuery: UseQueryResult<Page<ClassModel>>
+  clubsQuery: UseQueryResult<Page<ClubModel>>
+}
+
+interface TabPanelProps {
+  children?: ReactNode
+  index: number
+  value: number
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  )
 }
 
 export default function ClassSelector(props: ClassSelectorProps) {
   const { t } = useTranslation()
 
   const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [currentTab, setCurrentTab] = useState<number>(0)
 
   const handleClassClick = (newClass: ClassModel): void => {
-    props.setActiveClassId(newClass.id)
+    props.setActiveClassClubId(newClass.id, true)
+    setIsOpen(false)
+  }
+
+  const handleClubClick = (newClub: ClubModel): void => {
+    props.setActiveClassClubId(newClub.id, false)
     setIsOpen(false)
   }
 
@@ -37,22 +70,24 @@ export default function ClassSelector(props: ClassSelectorProps) {
     <Box>
       <FormControl
         sx={{
-          maxWidth: 150,
+          maxWidth: 300,
           cursor: "pointer",
         }}
         onClick={() => setIsOpen(true)} // Clicking anywhere opens dialog
       >
-        <InputLabel shrink={!!props.activeClass}>{t("ResultsStage.Class")}</InputLabel>
+        <InputLabel shrink={!!props.activeClassClub}>
+          {props.isClass ? t("ResultsStage.Class") : t("ResultsStage.Club")}
+        </InputLabel>
         <OutlinedInput
           readOnly
-          notched={!!props.activeClass}
-          value={props.activeClass?.short_name || ""}
+          notched={!!props.activeClassClub}
+          value={props.activeClassClub?.short_name || ""}
           endAdornment={
             <InputAdornment position="end">
               <ExpandMoreIcon />
             </InputAdornment>
           }
-          label={t("ResultsStage.Class")}
+          label={props.isClass ? t("ResultsStage.Class") : t("ResultsStage.Club")}
           sx={{
             pointerEvents: "none", // disable internal input interaction
           }}
@@ -62,17 +97,39 @@ export default function ClassSelector(props: ClassSelectorProps) {
         />
       </FormControl>
       <Dialog open={isOpen} onClose={() => setIsOpen(false)} maxWidth={"xs"} fullWidth>
-        <DialogTitle>{t("ResultsStage.Class")}</DialogTitle>
         <DialogContent>
-          <List>
-            {props.classesList.map((item) => {
+          <Tabs value={currentTab} onChange={(_, newValue: number) => setCurrentTab(newValue)}>
+            <Tab
+              label={t("ResultsStage.Classes")}
+              icon={<LeaderboardOutlinedIcon />}
+              iconPosition={"start"}
+            />
+            <Tab
+              label={t("ResultsStage.Clubs")}
+              icon={<GroupsOutlinedIcon />}
+              iconPosition={"start"}
+            />
+          </Tabs>
+          <CustomTabPanel value={currentTab} index={0}>
+            <List>
+              {props.classesQuery.data?.data.map((item) => {
+                return (
+                  <ListItemButton key={item.id} onClick={() => handleClassClick(item)}>
+                    <ListItemText>{item.short_name}</ListItemText>
+                  </ListItemButton>
+                )
+              })}
+            </List>
+          </CustomTabPanel>
+          <CustomTabPanel value={currentTab} index={1}>
+            {props.clubsQuery.data?.data.map((item) => {
               return (
-                <ListItemButton onClick={() => handleClassClick(item)}>
+                <ListItemButton key={item.id} onClick={() => handleClubClick(item)}>
                   <ListItemText>{item.short_name}</ListItemText>
                 </ListItemButton>
               )
             })}
-          </List>
+          </CustomTabPanel>
         </DialogContent>
       </Dialog>
     </Box>

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector.tsx
@@ -1,6 +1,20 @@
-import { Box, FormControl, InputLabel, MenuItem, Select } from "@mui/material"
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputAdornment,
+  InputLabel,
+  List,
+  ListItemButton,
+  ListItemText,
+  OutlinedInput,
+} from "@mui/material"
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import { useTranslation } from "react-i18next"
 import { ClassModel } from "../../../../../../../shared/EntityTypes.ts"
+import { useState } from "react"
 
 interface ClassSelectorProps {
   activeClass: ClassModel | null
@@ -12,31 +26,55 @@ interface ClassSelectorProps {
 export default function ClassSelector(props: ClassSelectorProps) {
   const { t } = useTranslation()
 
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  const handleClassClick = (newClass: ClassModel): void => {
+    props.setActiveClassId(newClass.id)
+    setIsOpen(false)
+  }
+
   return (
     <Box>
-      <FormControl sx={{ minWidth: "10em" }} required>
-        <InputLabel>{t("ResultsStage.Class")}</InputLabel>
-        <Select
-          id="class-selector-Select-Form"
+      <FormControl
+        sx={{
+          maxWidth: 150,
+          cursor: "pointer",
+        }}
+        onClick={() => setIsOpen(true)} // Clicking anywhere opens dialog
+      >
+        <InputLabel shrink={!!props.activeClass}>{t("ResultsStage.Class")}</InputLabel>
+        <OutlinedInput
+          readOnly
+          notched={!!props.activeClass}
+          value={props.activeClass?.short_name || ""}
+          endAdornment={
+            <InputAdornment position="end">
+              <ExpandMoreIcon />
+            </InputAdornment>
+          }
           label={t("ResultsStage.Class")}
-          onChange={(event) => props.setActiveClassId(event.target.value)}
-          value={props.isLoading ? "loading" : props.activeClass ? props.activeClass.id : ""}
-        >
-          {props.isLoading ? (
-            <MenuItem key={"Loading"} value={"loading"}>
-              {t("Loading")}
-            </MenuItem>
-          ) : (
-            props.classesList?.map((class_item) => {
-              return (
-                <MenuItem key={class_item.id} value={class_item.id}>
-                  {class_item.short_name}
-                </MenuItem>
-              )
-            })
-          )}
-        </Select>
+          sx={{
+            pointerEvents: "none", // disable internal input interaction
+          }}
+          inputProps={{
+            tabIndex: -1,
+          }}
+        />
       </FormControl>
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} maxWidth={"xs"} fullWidth>
+        <DialogTitle>{t("ResultsStage.Class")}</DialogTitle>
+        <DialogContent>
+          <List>
+            {props.classesList.map((item) => {
+              return (
+                <ListItemButton onClick={() => handleClassClick(item)}>
+                  <ListItemText>{item.short_name}</ListItemText>
+                </ListItemButton>
+              )
+            })}
+          </List>
+        </DialogContent>
+      </Dialog>
     </Box>
   )
 }

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/ClassSelector.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/ClassSelector.tsx
@@ -40,15 +40,16 @@ function CustomTabPanel(props: TabPanelProps) {
   const { children, value, index, ...other } = props
 
   return (
-    <div
+    <Box
       role="tabpanel"
       hidden={value !== index}
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
       {...other}
+      sx={{ height: "100%" }}
     >
-      {value === index && <Box>{children}</Box>}
-    </div>
+      {value === index && <Box sx={{ height: "100%" }}>{children}</Box>}
+    </Box>
   )
 }
 
@@ -108,14 +109,12 @@ export default function ClassSelector(props: ClassSelectorProps) {
         sx={{
           "& .MuiDialog-paper": {
             height: "90%",
-            maxHeight: "none"
+            maxHeight: "none",
           },
         }}
         fullWidth
       >
-        <DialogContent
-
-        >
+        <DialogContent sx={{ height: "100%" }}>
           <Tabs value={currentTab} onChange={(_, newValue: number) => setCurrentTab(newValue)}>
             <Tab
               label={t("ResultsStage.Classes")}
@@ -135,6 +134,7 @@ export default function ClassSelector(props: ClassSelectorProps) {
               keyExtractor={(classItem: ClassModel) => classItem.id}
               handleClick={handleClassClick}
               normalizeQuery={ignoreDashes}
+              isLoading={props.classesQuery.isLoading || props.classesQuery.isFetching}
             />
           </CustomTabPanel>
           <CustomTabPanel value={currentTab} index={1}>
@@ -144,6 +144,7 @@ export default function ClassSelector(props: ClassSelectorProps) {
               keyExtractor={(club: ClubModel) => club.id}
               handleClick={handleClubClick}
               normalizeQuery={ignoreDashesAndUnderscores}
+              isLoading={props.clubsQuery.isLoading || props.clubsQuery.isFetching}
             />
           </CustomTabPanel>
         </DialogContent>

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/ClassSelector.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/ClassSelector.tsx
@@ -47,7 +47,7 @@ function CustomTabPanel(props: TabPanelProps) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+      {value === index && <Box>{children}</Box>}
     </div>
   )
 }
@@ -101,8 +101,21 @@ export default function ClassSelector(props: ClassSelectorProps) {
           }}
         />
       </FormControl>
-      <Dialog open={isOpen} onClose={() => setIsOpen(false)} maxWidth={"xs"} fullWidth>
-        <DialogContent>
+      <Dialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        maxWidth={"xs"}
+        sx={{
+          "& .MuiDialog-paper": {
+            height: "90%",
+            maxHeight: "none"
+          },
+        }}
+        fullWidth
+      >
+        <DialogContent
+
+        >
           <Tabs value={currentTab} onChange={(_, newValue: number) => setCurrentTab(newValue)}>
             <Tab
               label={t("ResultsStage.Classes")}

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/ClassSelector.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/ClassSelector.tsx
@@ -12,11 +12,12 @@ import {
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import { useTranslation } from "react-i18next"
 import { ClassModel, ClubModel, Page } from "../../../../../../../../shared/EntityTypes.ts"
-import { ReactNode, useState } from "react"
+import { ReactNode, useEffect, useRef, useState } from "react"
 import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined"
 import LeaderboardOutlinedIcon from "@mui/icons-material/LeaderboardOutlined"
 import { UseQueryResult } from "react-query"
 import AutocompleteList from "./components/autocompleteList/AutocompleteList.tsx"
+import { useClassClubSearchParams } from "../../../../../../shared/hooks.ts"
 
 interface ClassSelectorProps {
   isClass: boolean
@@ -59,6 +60,31 @@ export default function ClassSelector(props: ClassSelectorProps) {
   // Internal states
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [currentTab, setCurrentTab] = useState<number>(0)
+
+  // Check if it should be opened or closed
+  const { getClassClubSearchParamName } = useClassClubSearchParams()
+
+  const hasInitialized = useRef(false)
+  useEffect(() => {
+    if (hasInitialized.current) return
+
+    const [item, isClassInSearchParam] = getClassClubSearchParamName()
+    hasInitialized.current = true
+
+    if (item !== null && isClassInSearchParam !== null) {
+      // Provided in the searchParam
+      if (isClassInSearchParam) {
+        // isClass
+        setCurrentTab(0)
+      } else {
+        // isClub
+        setCurrentTab(1)
+      }
+    } else {
+      // Prompt user to choose class
+      setIsOpen(true)
+    }
+  }, [getClassClubSearchParamName])
 
   // Click handlers
   const handleClassClick = (newClass: ClassModel): void => {

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/AutocompleteList.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/AutocompleteList.tsx
@@ -10,6 +10,7 @@ interface AutocompleteListProps<T> {
   keyExtractor: (item: T) => string
   handleClick: (item: T) => void
   normalizeQuery?: (query: string) => string
+  isLoading?: boolean
 }
 
 export default function AutocompleteList<T>({
@@ -18,6 +19,7 @@ export default function AutocompleteList<T>({
   keyExtractor,
   handleClick,
   normalizeQuery,
+  isLoading,
 }: AutocompleteListProps<T>) {
   // Internal state
   const [query, setQuery] = useState<string>("")
@@ -40,9 +42,9 @@ export default function AutocompleteList<T>({
 
   // Actual component
   return (
-    <Box sx={{ padding: 0, width: "100%" }}>
+    <Box sx={{ padding: 0, width: "100%", height: "100%" }}>
       <AutocompleteListSearchBar value={query} setValue={setQuery} />
-      <AutocompleteListContainer>
+      <AutocompleteListContainer isLoading={isLoading}>
         {displayedList.map((item) => {
           return (
             <AutocompleteListItem

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/AutocompleteList.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/AutocompleteList.tsx
@@ -1,0 +1,58 @@
+import AutocompleteListContainer from "./components/AutocompleteListContainer.tsx"
+import { Box } from "@mui/material"
+import AutocompleteListItem from "./components/AutocompleteListItem.tsx"
+import { useMemo, useState } from "react"
+import AutocompleteListSearchBar from "./components/AutocompleteListSearchBar.tsx"
+
+interface AutocompleteListProps<T> {
+  itemList: T[]
+  nameExtractor: (item: T) => string
+  keyExtractor: (item: T) => string
+  handleClick: (item: T) => void
+  normalizeQuery?: (query: string) => string
+}
+
+export default function AutocompleteList<T>({
+  itemList,
+  nameExtractor,
+  keyExtractor,
+  handleClick,
+  normalizeQuery,
+}: AutocompleteListProps<T>) {
+  // Internal state
+  const [query, setQuery] = useState<string>("")
+
+  const internalNormalizeQuery = useMemo(
+    () =>
+      normalizeQuery
+        ? (query: string) => normalizeQuery(query).toLowerCase()
+        : (query: string) => query.toLowerCase(),
+    [normalizeQuery],
+  )
+
+  // Filter the item list based on the search query
+  const displayedList = useMemo(() => {
+    const normalizeQuery = internalNormalizeQuery(query)
+    return itemList.filter((item) =>
+      internalNormalizeQuery(nameExtractor(item)).includes(normalizeQuery),
+    )
+  }, [itemList, query, nameExtractor, internalNormalizeQuery])
+
+  // Actual component
+  return (
+    <Box sx={{ paddingY: "24px", paddingX: 0 }}>
+      <AutocompleteListSearchBar value={query} setValue={setQuery} />
+      <AutocompleteListContainer>
+        {displayedList.map((item) => {
+          return (
+            <AutocompleteListItem
+              key={keyExtractor(item)}
+              name={nameExtractor(item)}
+              onClick={() => handleClick(item)}
+            />
+          )
+        })}
+      </AutocompleteListContainer>
+    </Box>
+  )
+}

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/AutocompleteList.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/AutocompleteList.tsx
@@ -40,7 +40,7 @@ export default function AutocompleteList<T>({
 
   // Actual component
   return (
-    <Box sx={{ paddingY: "24px", paddingX: 0 }}>
+    <Box sx={{ padding: 0, width: "100%" }}>
       <AutocompleteListSearchBar value={query} setValue={setQuery} />
       <AutocompleteListContainer>
         {displayedList.map((item) => {

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListContainer.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListContainer.tsx
@@ -1,6 +1,18 @@
 import { ReactNode } from "react"
 import { List } from "@mui/material"
+import AutocompleteListSkeletonItem from "./AutocompleteListSkeletonItem.tsx"
+import ListSkeleton from "../../../../../../../../../../../components/ListSkeleton/ListSkeleton.tsx"
 
-export default function AutocompleteListContainer({ children }: { children: ReactNode }) {
-  return <List sx={{ padding: 0 }}>{children}</List>
+export default function AutocompleteListContainer({
+  children,
+  isLoading,
+}: {
+  children: ReactNode
+  isLoading?: boolean
+}) {
+  if (isLoading) {
+    return <ListSkeleton SkeletonItem={AutocompleteListSkeletonItem} gap={"8px"} />
+  } else {
+    return <List sx={{ padding: 0, flexGrow: 1 }}>{children}</List>
+  }
 }

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListContainer.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListContainer.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from "react"
+import { List } from "@mui/material"
+
+export default function AutocompleteListContainer({ children }: { children: ReactNode }) {
+  return <List sx={{ padding: 0 }}>{children}</List>
+}

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListItem.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListItem.tsx
@@ -1,0 +1,14 @@
+import { ListItemButton, ListItemText } from "@mui/material"
+
+interface AutocompleteListItemProps {
+  name: string
+  onClick?: () => void
+}
+
+export default function AutocompleteListItem({ name, onClick }: AutocompleteListItemProps) {
+  return (
+    <ListItemButton onClick={onClick}>
+      <ListItemText>{name}</ListItemText>
+    </ListItemButton>
+  )
+}

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListSearchBar.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListSearchBar.tsx
@@ -1,0 +1,49 @@
+import { IconButton, InputAdornment, TextField } from "@mui/material"
+import { useTranslation } from "react-i18next"
+import { ClearIcon } from "@mui/x-date-pickers"
+import SearchIcon from "@mui/icons-material/Search"
+import Tooltip from "@mui/material/Tooltip"
+
+interface AutocompleteListSearchBarProps {
+  value: string
+  setValue: (query: string) => void
+}
+
+export default function AutocompleteListSearchBar({
+  value,
+  setValue,
+}: AutocompleteListSearchBarProps) {
+  const { t } = useTranslation()
+
+  return (
+    <TextField
+      fullWidth
+      placeholder={t("Search.Search")}
+      variant="outlined"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      sx={{ marginBottom: 2 }}
+      slotProps={{
+        input: {
+          endAdornment: value ? (
+            <InputAdornment position="end">
+              <Tooltip title={t("Search.ClearSearch")}>
+                <IconButton
+                  size="small"
+                  onClick={() => setValue("")}
+                  aria-label={t("Clear search")}
+                >
+                  <ClearIcon />
+                </IconButton>
+              </Tooltip>
+            </InputAdornment>
+          ) : (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        },
+      }}
+    />
+  )
+}

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListSearchBar.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListSearchBar.tsx
@@ -17,14 +17,14 @@ export default function AutocompleteListSearchBar({
 
   return (
     <TextField
-      fullWidth
       placeholder={t("Search.Search")}
-      variant="outlined"
+      variant="standard"
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      sx={{ marginBottom: 2 }}
+      sx={{ marginY: 2, width: "100%" }}
       slotProps={{
         input: {
+          sx: { mx: "10px", mt: "5px" },
           endAdornment: value ? (
             <InputAdornment position="end">
               <Tooltip title={t("Search.ClearSearch")}>

--- a/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListSkeletonItem.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/components/ClassSelector/components/autocompleteList/components/AutocompleteListSkeletonItem.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@mui/material"
+
+export default function AutocompleteListSkeletonItem() {
+  return <Skeleton variant={"rounded"} width={"100%"} height={"48px"} />
+}

--- a/src/pages/Results/pages/Results/pages/FootO/FootO.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/FootO.tsx
@@ -60,6 +60,7 @@ export default function FootO() {
         : Promise.reject(new Error("No active club")),
     {
       enabled: !!activeItem && !isClass,
+      refetchOnWindowFocus: false,
     },
   )
 

--- a/src/pages/Results/pages/Results/pages/FootO/components/FootOVirtualTicket/FootOVirtualTicket.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/components/FootOVirtualTicket/FootOVirtualTicket.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from "react"
+import { CSSProperties } from "react"
 import {
   VirtualTicketContainer,
   VirtualTicketProps,
@@ -11,20 +11,24 @@ import FootOVirtualTicketSplit from "./components/FootOVirtualTicketSplit.tsx"
 import { Grid, Typography } from "@mui/material"
 import { useTranslation } from "react-i18next"
 import { hasChipDownload } from "../../../../shared/functions.ts"
+import GeneralErrorFallback from "../../../../../../../../components/GeneralErrorFallback.tsx"
+import ListSkeleton from "../../../../../../../../components/ListSkeleton/ListSkeleton.tsx"
+import FootOVirtualTicketSplitSkeletonItem from "./components/FootOVirtualTicketSplitSkeletonItem.tsx"
+import { useFillClubRunner } from "./shared/hooks.ts"
+
+interface FootOVirtualTicketProps extends VirtualTicketProps {
+  isClass?: boolean
+}
 
 /**
  * This is the Virtual Ticket for Foot-O results
- *
- * @param isTicketOpen
- * @param runner
- * @param handleCloseTicket
- * @constructor
  */
-const FootOVirtualTicket: React.FC<VirtualTicketProps> = ({
+export default function FootOVirtualTicket({
   isTicketOpen,
   runner,
   handleCloseTicket,
-}) => {
+  isClass,
+}: FootOVirtualTicketProps) {
   const { t } = useTranslation()
 
   const headersStyles: CSSProperties = {
@@ -33,18 +37,24 @@ const FootOVirtualTicket: React.FC<VirtualTicketProps> = ({
     textAlign: "center",
   }
 
-  if (runner) {
+  const {
+    runner: displayedRunner,
+    isLoading,
+    isError,
+  } = useFillClubRunner(runner, !isClass && runner != null)
+
+  if (displayedRunner) {
     return (
       <VirtualTicketContainer
         isTicketOpen={isTicketOpen}
-        runner={runner}
+        runner={displayedRunner}
         handleCloseTicket={handleCloseTicket}
       >
         <VirtualTicketHeader>
-          <VirtualTicketRunnerInfo runner={runner} />
-          <FootOVirtualTicketTimesBanner runnerResult={runner.overall} />
+          <VirtualTicketRunnerInfo runner={displayedRunner} />
+          <FootOVirtualTicketTimesBanner runnerResult={displayedRunner.overall} />
         </VirtualTicketHeader>
-        <VirtualTicketSplits download={hasChipDownload(runner)}>
+        <VirtualTicketSplits download={hasChipDownload(displayedRunner)}>
           <Grid item xs={2}>
             <Typography sx={headersStyles}>{t("ResultsStage.VirtualTicket.Control")}</Typography>
           </Grid>
@@ -54,9 +64,19 @@ const FootOVirtualTicket: React.FC<VirtualTicketProps> = ({
           <Grid item xs={5}>
             <Typography sx={headersStyles}>{t("ResultsStage.VirtualTicket.Cumulative")}</Typography>
           </Grid>
-          {runner.overall.splits.map((split, index) => (
-            <FootOVirtualTicketSplit key={split.id} split={split} index={index} />
-          ))}
+          {!isLoading ? (
+            displayedRunner.overall.splits.map((split, index) => (
+              <FootOVirtualTicketSplit key={split.id} split={split} index={index} />
+            ))
+          ) : isError ? (
+            <GeneralErrorFallback />
+          ) : (
+            <ListSkeleton
+              SkeletonItem={FootOVirtualTicketSplitSkeletonItem}
+              gap={"10px"}
+              minItems={10}
+            />
+          )}
         </VirtualTicketSplits>
       </VirtualTicketContainer>
     )
@@ -64,5 +84,3 @@ const FootOVirtualTicket: React.FC<VirtualTicketProps> = ({
     return <></>
   }
 }
-
-export default FootOVirtualTicket

--- a/src/pages/Results/pages/Results/pages/FootO/components/FootOVirtualTicket/components/FootOVirtualTicketSplitSkeletonItem.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/components/FootOVirtualTicket/components/FootOVirtualTicketSplitSkeletonItem.tsx
@@ -1,0 +1,15 @@
+import { Grid, Skeleton } from "@mui/material"
+
+export default function FootOVirtualTicketSplitSkeletonItem() {
+  return (
+    <Grid
+      item
+      xs={12}
+      sx={{ width: "100%", display: "flex", flexDirection: "row", justifyContent: "space-between" }}
+    >
+      <Skeleton variant={"rounded"} width={"70px"} height={"39px"} />
+      <Skeleton variant={"rounded"} width={"120px"} height={"39px"} />
+      <Skeleton variant={"rounded"} width={"120px"} height={"39px"} />
+    </Grid>
+  )
+}

--- a/src/pages/Results/pages/Results/pages/FootO/components/FootOVirtualTicket/shared/hooks.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/components/FootOVirtualTicket/shared/hooks.ts
@@ -1,0 +1,29 @@
+import { ProcessedRunnerModel } from "../../../../../../../components/VirtualTicket/shared/EntityTypes.ts"
+import { useQuery } from "react-query"
+import { getFootORunnersByClass } from "../../../services/FootOService.ts"
+import { useParams } from "react-router-dom"
+
+export function useFillClubRunner(
+  clubRunner: ProcessedRunnerModel | null,
+  enabled: boolean = true,
+): { runner: ProcessedRunnerModel | null; isLoading: boolean; isError: boolean } {
+  const { eventId, stageId } = useParams()
+  if (!eventId || !stageId) throw new Error("Missing event or stage ID")
+
+  const { data, isLoading, isError } = useQuery<ProcessedRunnerModel[]>(
+    [eventId, stageId, "results", "classes", clubRunner?.class.id],
+    () => getFootORunnersByClass(eventId, stageId, clubRunner!.class.id),
+    {
+      enabled: enabled && !!clubRunner,
+      refetchOnWindowFocus: false,
+      staleTime: 60000,
+    },
+  )
+  //console.log("enabled", enabled, "clubRunner", clubRunner, "data", data)
+  const runner =
+    !enabled || !clubRunner || !data
+      ? clubRunner
+      : (data.find((r) => r.id === clubRunner.id) ?? clubRunner)
+
+  return { runner, isLoading, isError }
+}

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Results/FootOResults.tsx
@@ -29,7 +29,7 @@ export default function FootOResults(
   const [isVirtualTicketOpen, selectedRunner, handleRowClick, handleCloseVirtualTicket] =
     useVirtualTicket()
 
-  if (!props.activeClass) {
+  if (!props.activeItem) {
     return <ChooseClassMsg />
   }
   if (props.runnersQuery.isFetching) {
@@ -55,7 +55,11 @@ export default function FootOResults(
               </FlexCol>
               <ParticipantName
                 name={runner.full_name}
-                subtitle={runnerService.getClubName(runner, t)}
+                subtitle={
+                  props.isClass
+                    ? runnerService.getClubName(runner, t)
+                    : runnerService.getClassName(runner)
+                }
               />
               <FlexCol flexGrow={1}>
                 <RaceTime

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
@@ -10,6 +10,7 @@ import { useState } from "react"
 import { FormControlLabel, Switch } from "@mui/material"
 import ExperimentalFeatureAlert from "../../../../../../../../components/ExperimentalFeatureAlert.tsx"
 import PartialCumulativeSwitch from "./components/PartialCumulativeSwitch.tsx"
+import OnlyForClassesMsg from "./components/OnlyForClassesMsg.tsx"
 
 export default function FootOSplits(
   props: ResultsPageProps<ProcessedRunnerModel[], AxiosError<RunnerModel[]>>,
@@ -18,8 +19,10 @@ export default function FootOSplits(
   const [showCumulative, setShowCumulative] = useState<boolean>(false)
   const [showCumulativeDisplayed, setShowCumulativeDisplayed] = useState<boolean>(false)
 
-  if (!props.activeClass) {
+  if (!props.activeItem) {
     return <ChooseClassMsg />
+  } else if (!props.isClass) {
+    return <OnlyForClassesMsg />
   } else if (props.runnersQuery.isFetching) {
     return <GeneralSuspenseFallback />
   } else if (props.runnersQuery.isError) {
@@ -36,7 +39,7 @@ export default function FootOSplits(
           }}
           disabled={onlyRadios}
         />
-        {props.activeClass.splits.length > 0 ? (
+        {"splits" in props.activeItem && props.activeItem.splits.length > 0 ? (
           <FormControlLabel
             control={
               <Switch
@@ -57,7 +60,7 @@ export default function FootOSplits(
         )}
         <FootOSplitsTable
           onlyRadios={onlyRadios}
-          radiosList={props.activeClass.splits}
+          radiosList={"splits" in props.activeItem ? props.activeItem.splits : []}
           showCumulative={showCumulative}
           key={"FootOSplitsTable"}
           runners={props.runnersQuery.data ? props.runnersQuery.data : []}

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/OnlyForClassesMsg.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/OnlyForClassesMsg.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from "react-i18next"
+import { Alert, AlertTitle } from "@mui/material"
+
+export default function OnlyForClassesMsg() {
+  const { t } = useTranslation()
+
+  return (
+    <Alert severity={"info"}>
+      <AlertTitle>{t("ResultsStage.SplitsTable.OnlyForClasses")}</AlertTitle>
+    </Alert>
+  )
+}

--- a/src/pages/Results/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/StartTime/FootOStartTime.tsx
@@ -33,7 +33,7 @@ export default function FootOStartTime(
   }, [rawRunnersList])
 
   // Component
-  if (!props.activeClass) {
+  if (!props.activeItem) {
     return <ChooseClassMsg />
   } else if (props.runnersQuery.isFetching || props.runnersQuery.isLoading) {
     return <ResultsListSkeleton />
@@ -48,7 +48,11 @@ export default function FootOStartTime(
               <FlexRow>
                 <ParticipantName
                   name={runner.full_name}
-                  subtitle={runnerService.getClubName(runner, t)}
+                  subtitle={
+                    props.isClass
+                      ? runnerService.getClubName(runner, t)
+                      : runnerService.getClassName(runner)
+                  }
                 />
                 <FlexCol>
                   <StartTime

--- a/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
@@ -1,6 +1,6 @@
 import { ProcessedRunnerModel } from "../../../../../components/VirtualTicket/shared/EntityTypes.ts"
 import { getRunnersInStage } from "../../../../../services/EventService.ts"
-import { orderedRunners, orderRunnersByClass } from "../../../../../shared/functions.ts"
+import { orderedRunners } from "../../../../../shared/functions.ts"
 import {
   calculatePositionsAndBehindsFootO,
   processRunnerData,
@@ -46,7 +46,6 @@ export async function getFootORunnersByClub(
 
   // Order
   runnersList = orderedRunners(runnersList)
-  runnersList = orderRunnersByClass(runnersList)
 
   // Processing
   return processRunnerData(runnersList)

--- a/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
@@ -1,6 +1,6 @@
 import { ProcessedRunnerModel } from "../../../../../components/VirtualTicket/shared/EntityTypes.ts"
 import { getRunnersInStage } from "../../../../../services/EventService.ts"
-import { orderedRunners } from "../../../../../shared/functions.ts"
+import { orderedRunners, orderRunnersByClass } from "../../../../../shared/functions.ts"
 import {
   calculatePositionsAndBehindsFootO,
   processRunnerData,
@@ -34,4 +34,20 @@ export async function getFootORunnersByClass(
 
   // return
   return processedRunnersList
+}
+
+export async function getFootORunnersByClub(
+  eventId: string,
+  stageId: string,
+  clubId: string,
+): Promise<ProcessedRunnerModel[]> {
+  const runnersPage = await getRunnersInStage(eventId, stageId, undefined, clubId)
+  let runnersList = runnersPage.data
+
+  // Order
+  runnersList = orderedRunners(runnersList)
+  runnersList = orderRunnersByClass(runnersList)
+
+  // Processing
+  return processRunnerData(runnersList)
 }

--- a/src/pages/Results/pages/Results/pages/Relay/Relay.tsx
+++ b/src/pages/Results/pages/Results/pages/Relay/Relay.tsx
@@ -26,35 +26,43 @@ export default function Relay() {
     throw new Error("Event Id or Stage Id is missing")
   }
 
-  const [activeClass, setActiveClassId, classesList, areClassesLoading, refreshClasses] =
-    useFetchClasses()
+  const {
+    activeItem,
+    classesQuery,
+    clubsQuery,
+    isClass,
+    setClassClubId,
+    refresh: refreshClassesClubs,
+  } = useFetchClasses()
 
   // Query runners
   const runnersQueryByClasses = useQuery<ProcessedRunnerModel[], AxiosError<RunnerModel[]>>(
-    ["results", "classes", activeClass?.id],
+    ["results", "classes", activeItem?.id],
     () =>
-      activeClass
-        ? getRelayRunnersByClass(eventId, stageId, activeClass.id)
+      activeItem
+        ? getRelayRunnersByClass(eventId, stageId, activeItem.id)
         : Promise.reject(new Error("No active class")),
     {
-      enabled: !!activeClass,
+      enabled: !!activeItem && isClass,
       refetchOnWindowFocus: false,
     },
   )
 
   // Handle re-fetching
   const handleRefreshClick = useCallback(() => {
-    refreshClasses()
+    refreshClassesClubs()
     void runnersQueryByClasses.refetch()
-  }, [refreshClasses, runnersQueryByClasses])
+  }, [refreshClassesClubs, runnersQueryByClasses])
 
   return (
     <StageLayout
+      key={"stageLayout"}
+      activeItem={activeItem}
+      isClass={isClass}
+      classesQuery={classesQuery}
+      clubsQuery={clubsQuery}
+      setActiveClassClub={setClassClubId}
       handleRefreshClick={handleRefreshClick}
-      classesList={classesList}
-      setActiveClassId={setActiveClassId}
-      activeClass={activeClass}
-      areClassesLoading={areClassesLoading}
     >
       <ResultTabs
         defaultMenu={0}
@@ -72,8 +80,8 @@ export default function Relay() {
         ]}
         menuOptionsLabels={menu_options_labels}
       >
-        <RelayResults runnersQuery={runnersQueryByClasses} activeClass={activeClass} />
-        <RelayLegs runnersQuery={runnersQueryByClasses} activeClass={activeClass} />
+        <RelayResults runnersQuery={runnersQueryByClasses} activeItem={activeItem} isClass={isClass}/>
+        <RelayLegs runnersQuery={runnersQueryByClasses} activeItem={activeItem} isClass={isClass}/>
       </ResultTabs>
     </StageLayout>
   )

--- a/src/pages/Results/pages/Results/pages/Relay/Relay.tsx
+++ b/src/pages/Results/pages/Results/pages/Relay/Relay.tsx
@@ -80,8 +80,12 @@ export default function Relay() {
         ]}
         menuOptionsLabels={menu_options_labels}
       >
-        <RelayResults runnersQuery={runnersQueryByClasses} activeItem={activeItem} isClass={isClass}/>
-        <RelayLegs runnersQuery={runnersQueryByClasses} activeItem={activeItem} isClass={isClass}/>
+        <RelayResults
+          runnersQuery={runnersQueryByClasses}
+          activeItem={activeItem}
+          isClass={isClass}
+        />
+        <RelayLegs runnersQuery={runnersQueryByClasses} activeItem={activeItem} isClass={isClass} />
       </ResultTabs>
     </StageLayout>
   )

--- a/src/pages/Results/pages/Results/pages/Relay/pages/RelayResults/RelayResults.tsx
+++ b/src/pages/Results/pages/Results/pages/Relay/pages/RelayResults/RelayResults.tsx
@@ -18,7 +18,7 @@ export default function RelayResults(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleRowClick = (runner: RunnerModel) => {}
 
-  if (!props.activeClass) {
+  if (!props.activeItem) {
     return <ChooseClassMsg />
   }
   if (props.runnersQuery.isFetching) {

--- a/src/pages/Results/pages/Results/pages/Rogaine/pages/RogainePoints/RogainePoints.tsx
+++ b/src/pages/Results/pages/Results/pages/Rogaine/pages/RogainePoints/RogainePoints.tsx
@@ -16,6 +16,7 @@ import { AxiosError } from "axios"
 import { RunnerModel } from "../../../../../../../../shared/EntityTypes.ts"
 import RacePosition from "../../../../../../components/RacePosition..tsx"
 import { hasChipDownload } from "../../../../shared/functions.ts"
+import OnlyForClassesMsg from "./components/OnlyForClassesMsg.tsx"
 
 export default function RogainePoints(
   props: ResultsPageProps<[ProcessedRunnerModel[], bigint[]], AxiosError<RunnerModel[]>>,
@@ -26,8 +27,10 @@ export default function RogainePoints(
   const controlNumbers = props.runnersQuery.data ? props.runnersQuery.data[1] : null
 
   // Component
-  if (!props.activeClass) {
+  if (!props.activeItem) {
     return <ChooseClassMsg />
+  } else if (!props.isClass) {
+    return <OnlyForClassesMsg />
   } else if (props.runnersQuery.isFetching || props.runnersQuery.isLoading) {
     return <ResultsListSkeleton />
   } else if (props.runnersQuery.isError) {

--- a/src/pages/Results/pages/Results/pages/Rogaine/pages/RogainePoints/components/OnlyForClassesMsg.tsx
+++ b/src/pages/Results/pages/Results/pages/Rogaine/pages/RogainePoints/components/OnlyForClassesMsg.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from "react-i18next"
+import { Alert, AlertTitle } from "@mui/material"
+
+export default function OnlyForClassesMsg() {
+  const { t } = useTranslation()
+
+  return (
+    <Alert severity={"info"}>
+      <AlertTitle>{t("ResultsStage.PointsTable.OnlyForClasses")}</AlertTitle>
+    </Alert>
+  )
+}

--- a/src/pages/Results/pages/Results/pages/Rogaine/pages/RogaineResults/RogaineResults.tsx
+++ b/src/pages/Results/pages/Results/pages/Rogaine/pages/RogaineResults/RogaineResults.tsx
@@ -31,7 +31,7 @@ export default function RogainePoints(
   const runnersList = props.runnersQuery.data ? props.runnersQuery.data[0] : null
 
   // Render component
-  if (!props.activeClass) {
+  if (!props.activeItem) {
     return <ChooseClassMsg />
   } else if (props.runnersQuery.isFetching || props.runnersQuery.isLoading) {
     return <ResultsListSkeleton />
@@ -67,7 +67,11 @@ export default function RogainePoints(
               </Box>
               <ParticipantName
                 name={runner.full_name}
-                subtitle={runnerService.getClubName(runner, t)}
+                subtitle={
+                  props.isClass
+                    ? runnerService.getClubName(runner, t)
+                    : runnerService.getClassName(runner)
+                }
               />
               <Box
                 sx={{

--- a/src/pages/Results/pages/Results/pages/Rogaine/services/RogaineService.ts
+++ b/src/pages/Results/pages/Results/pages/Rogaine/services/RogaineService.ts
@@ -1,6 +1,6 @@
 import { ProcessedRunnerModel } from "../../../../../components/VirtualTicket/shared/EntityTypes.ts"
 import { getRunnersInStage } from "../../../../../services/EventService.ts"
-import { orderedRunners } from "../../../../../shared/functions.ts"
+import { orderedRunners, orderRunnersByClass } from "../../../../../shared/functions.ts"
 import { processRunnerData } from "../../../../../components/VirtualTicket/shared/virtualTicketFunctions.ts"
 import { getUniqueStationNumbers } from "../shared/Functions.ts"
 
@@ -20,7 +20,7 @@ export async function getRoganineRunnersByClass(
   classId: string,
 ): Promise<[ProcessedRunnerModel[], bigint[]]> {
   // Make query
-  const runnersPage = await getRunnersInStage(eventId, stageId, classId)
+  const runnersPage = await getRunnersInStage(eventId, stageId, classId, undefined)
   let runnersList = runnersPage.data
 
   // Process runners
@@ -32,4 +32,21 @@ export async function getRoganineRunnersByClass(
 
   // return
   return [processedRunnersList, controls]
+}
+
+export async function getRoganineRunnersByClub(
+  eventId: string,
+  stageId: string,
+  clubId: string,
+): Promise<[ProcessedRunnerModel[], bigint[]]> {
+  // Make query
+  const runnersPage = await getRunnersInStage(eventId, stageId, undefined, clubId)
+  let runnersList = runnersPage.data
+
+  // Process runners
+  runnersList = orderedRunners(runnersList)
+  runnersList = orderRunnersByClass(runnersList)
+  const processedRunnersList = processRunnerData(runnersList)
+
+  return [processedRunnersList, []]
 }

--- a/src/pages/Results/pages/Results/shared/commonProps.ts
+++ b/src/pages/Results/pages/Results/shared/commonProps.ts
@@ -1,7 +1,8 @@
 import { UseQueryResult } from "react-query"
-import { ClassModel } from "../../../../../shared/EntityTypes.ts"
+import { ClassModel, ClubModel } from "../../../../../shared/EntityTypes.ts"
 
 export type ResultsPageProps<TData, TError> = {
   runnersQuery: UseQueryResult<TData, TError>
-  activeClass: ClassModel | null
+  activeItem: ClassModel | ClubModel | null
+  isClass: boolean
 }

--- a/src/pages/Results/services/EventService.ts
+++ b/src/pages/Results/services/EventService.ts
@@ -1,6 +1,7 @@
 import { get } from "../../../services/ApiConfig.ts"
 import {
   ClassModel,
+  ClubModel,
   Data,
   EventDetailModel,
   EventModel,
@@ -53,14 +54,38 @@ export async function getClassesInStage(
   return await get<Page<ClassModel>>(baseUrl + `/${event_id}/stages/${stage_id}/classes`)
 }
 
+/**
+ * Fetch all clubs that belong to a given stage
+ * @param event_id ID of the event that the stage belongs to
+ * @param stage_id ID of the stage we want to gather data from
+ */
+export async function getClubsInStage(
+  event_id: string,
+  stage_id: string,
+): Promise<Page<ClubModel>> {
+  return await get<Page<ClubModel>>(`${baseUrl}/${event_id}/stages/${stage_id}/clubs`)
+}
+
 export async function getRunnersInStage(
   event_id: string,
   stage_id: string,
   class_id?: string,
+  club_id?: string,
 ): Promise<Page<RunnerModel>> {
   let url = `/${event_id}/stages/${stage_id}/results`
+
+  // Set url search params
+  const urlSearchParam = new URLSearchParams()
+
   if (class_id) {
-    url = url + `?class_id=${class_id}&forceSameDay=1`
+    urlSearchParam.set("class_id", class_id)
   }
+  if (club_id) {
+    urlSearchParam.set("club_id", club_id)
+  }
+
+  // Build final url and make query
+  url = url + `?${urlSearchParam.toString()}`
+
   return await get<Page<RunnerModel>>(baseUrl + url)
 }

--- a/src/pages/Results/shared/functions.ts
+++ b/src/pages/Results/shared/functions.ts
@@ -138,3 +138,16 @@ export function orderedRunners(runnersList: RunnerModel[]) {
     return posA - posB // Compare positions numerically
   })
 }
+
+/**
+ * Sort a runner list by their class. Sorting is done in place
+ * @param runnersList Runners to be ordered
+ */
+export function orderRunnersByClass(runnersList: RunnerModel[]) {
+  return runnersList.sort((a, b) => {
+    const runnerClassA = a.class.short_name
+    const runnerClassB = b.class.short_name
+
+    return runnerClassA.localeCompare(runnerClassB)
+  })
+}

--- a/src/pages/Results/shared/hooks.ts
+++ b/src/pages/Results/shared/hooks.ts
@@ -1,88 +1,96 @@
 import { useCallback, useEffect, useState } from "react"
-import {
-  getClassesInStage,
-  getEventDetail,
-  getEventList,
-  getRunnersInStage,
-} from "../services/EventService.ts"
-import { ClassModel, EventModel } from "../../../shared/EntityTypes.ts"
-import { useLocation, useParams, useSearchParams } from "react-router-dom"
+import { getClassesInStage, getClubsInStage, getEventList } from "../services/EventService.ts"
+import { ClassModel, ClubModel, EventModel, Page } from "../../../shared/EntityTypes.ts"
+import { useParams, useSearchParams } from "react-router-dom"
 import { useAuth } from "../../../shared/hooks.ts"
-import {
-  calculatePositionsAndBehindsFootO,
-  processRunnerData,
-} from "../components/VirtualTicket/shared/virtualTicketFunctions.ts"
-import { ProcessedRunnerModel } from "../components/VirtualTicket/shared/EntityTypes.ts"
+import { useQuery, UseQueryResult } from "react-query"
 
-export function useFetchClasses(): [
-  ClassModel | null,
-  (class_id: string) => void,
-  ClassModel[],
-  boolean,
-  () => void,
-] {
-  const ACTIVE_CLASS_SEARCH_PARAM = "class_id"
+export function useFetchClasses(): {
+  activeItem: ClassModel | ClubModel | null
+  isClass: boolean
+  classesQuery: UseQueryResult<Page<ClassModel>>
+  clubsQuery: UseQueryResult<Page<ClubModel>>
+  refresh: () => void
+  setClassClubId: (newItemId: string, isClass: boolean) => void
+} {
+  //const ACTIVE_CLASS_SEARCH_PARAM = "class"
+  //const ACTIVE_CLUB_SEARCH_PARAM = "club"
 
   const { eventId, stageId } = useParams()
-  const [searchParams, setSearchParams] = useSearchParams()
+  //const [searchParams, setSearchParams] = useSearchParams()
 
   // Associated states
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [classesList, setClassesList] = useState<ClassModel[]>([])
-  const [activeClass, setActiveClassState] = useState<ClassModel | null>(null)
-  const [refreshTrigger, setRefreshTrigger] = useState(0)
+  const [activeItem, setActiveItem] = useState<ClassModel | ClubModel | null>(null)
+  const [isClass, setIsClass] = useState<boolean>(true)
 
   // HTTP request
-  useEffect(
-    () => {
-      const fetchClasses = async () => {
-        try {
-          const response = await getClassesInStage(eventId as string, stageId as string)
-          // set Classes list
-          setClassesList(response.data)
-
-          // set active class from URL if given
-          const new_active_class_id = searchParams.get(ACTIVE_CLASS_SEARCH_PARAM)
-          if (new_active_class_id) {
-            const new_active_class = response.data?.find((e) => e.id === new_active_class_id)
-            if (new_active_class) {
-              setActiveClassState(new_active_class)
-            } else {
-              console.log(
-                `Provided class id ${new_active_class_id} doesn't exist. The classes list is ${classesList.toString()}`,
-              )
-            }
-          }
-        } catch (error) {
-          console.error("error in get classes: ", error)
-        } finally {
-          setIsLoading(false)
-        }
-      }
-
-      void fetchClasses()
+  const classesQuery = useQuery(
+    ["classes", stageId, eventId],
+    () => getClassesInStage(eventId as string, stageId as string),
+    {
+      refetchOnWindowFocus: false,
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [refreshTrigger],
+  )
+
+  const clubsQuery = useQuery(
+    ["clubs", stageId, eventId],
+    () => getClubsInStage(eventId as string, stageId as string),
+    {
+      refetchOnWindowFocus: false,
+    },
   )
 
   // Set selected class function. It handles the search param usage
-  const setActiveClassId = (newActiveClassId: string) => {
-    const new_active_class = classesList.find((e) => e.id === newActiveClassId)
-    if (new_active_class) {
-      setActiveClassState(new_active_class)
-      searchParams.set(ACTIVE_CLASS_SEARCH_PARAM, newActiveClassId)
-      setSearchParams(searchParams, { replace: true })
-    } else {
-      console.error("The selected class is not valid")
+  //const setActiveClassId = (newActiveId: string,isClass: boolean) => {
+  //if (isClass) {
+  // Handle class selected
+  //const new_active_class = classesList.find((e) => e.id === newActiveId)
+  //if (new_active_class) {
+  //setActiveClassState(new_active_class)
+  //searchParams.set(ACTIVE_CLASS_SEARCH_PARAM, newActiveId)
+  //setSearchParams(searchParams, { replace: true })
+  //} else {
+  //  console.error("The selected class is not valid")
+  //}
+  //} else {
+  // Handle club selected
+  //const new_active_club = clubsList.find((e) => e.id === newActiveId)
+  //if (new_active_club) {
+  //  setActiveClub(new_active_club)
+  //} else {
+  //  console.error("The selected club is not valid")
+  //}
+  //}
+  //}
+
+  const setClassClub = (newItemId: string, isClass: boolean): void => {
+    setIsClass(isClass)
+
+    const desiredQuery: UseQueryResult<Page<ClassModel>> | UseQueryResult<Page<ClubModel>> = isClass
+      ? classesQuery
+      : clubsQuery
+    const newItem: ClubModel | ClassModel | undefined = desiredQuery.data?.data.find(
+      (c) => c.id === newItemId,
+    )
+
+    if (newItem) {
+      setActiveItem(newItem)
     }
   }
 
-  const refresh = useCallback(() => {
-    setRefreshTrigger((prev) => prev + 1)
-  }, [])
+  const refresh = useCallback((): void => {
+    void classesQuery.refetch()
+    void clubsQuery.refetch()
+  }, [classesQuery, clubsQuery])
 
-  return [activeClass, setActiveClassId, classesList, isLoading, refresh]
+  return {
+    activeItem: activeItem,
+    isClass: isClass,
+    classesQuery: classesQuery,
+    clubsQuery: clubsQuery,
+    refresh: refresh,
+    setClassClubId: setClassClub,
+  }
 }
 
 export function useFetchEvents(
@@ -150,125 +158,4 @@ export function useSelectedMenu(
   )
 
   return [selectedMenu, handleMenuChange]
-}
-
-export function useEventInfo() {
-  const { token } = useAuth()
-
-  const { eventId, stageId } = useParams()
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { state } = useLocation()
-
-  const [eventName, setEventName] = useState<string>("")
-  const [organizerName, setOrganizerName] = useState<string>("")
-  const [stageName, setStageName] = useState<string>("")
-  const [stageTypeId, setStageTypeId] = useState<string>("")
-  const [singleStage, setSingleStage] = useState<boolean>(false)
-
-  useEffect(
-    () => {
-      //Check if state is empty. If it is, gather info from backend. It will ve empty if the user has not landed in this page navigating
-      if (state === null) {
-        void getEventDetail(eventId as string, token).then((response) => {
-          // Event name
-          setEventName(response.data.description)
-
-          // Organizer name
-          setOrganizerName(response.data.organizer?.name as string)
-
-          // Single stage
-          if (response.data.stages.length == 1) {
-            setSingleStage(true)
-          } else {
-            setSingleStage(false)
-          }
-
-          // Stage info
-          const current_stage = response.data.stages.find((stage) => stage.id === stageId)
-          if (current_stage) {
-            setStageName(response.data.description)
-            setStageTypeId(current_stage.stage_type.id)
-          } else {
-            throw new Error(
-              `The stage ${stageId} does not belong to ${eventId} (${response.data.description}).`,
-            ) //TODO: redirect to 404 not found
-          }
-        })
-
-        //Stage info came from router state. No extra backend call required
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-        setEventName(state.eventName)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-        setStageName(state.stageName)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-        setStageTypeId(state.stageTypeId)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-        setSingleStage(state.singleStage)
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  )
-
-  return {
-    eventId: eventId as string,
-    eventName: eventName,
-    organizerName: organizerName,
-    stageId: stageId as string,
-    stageName: stageName,
-    stageTypeId: stageTypeId,
-    singleStage: singleStage,
-  }
-}
-
-/**
- * Get the runner list from the server associated with the event, stage and class. When the class
- * is provided as a state, the list will be updated automatically if any of the three params gets
- * updated.
- * @param event_id
- * @param stage_id
- * @param activeClass
- * @returns A list [runnerList,isLoading]
- * @returns runnersList:RunnerModel[] state with the desired runners
- * @returns isLoading:boolean state to know when result are being fetch
- */
-export function useRunners(
-  event_id: string,
-  stage_id: string,
-  activeClass: ClassModel | null,
-): [ProcessedRunnerModel[], boolean, () => void] {
-  const [isLoading, setIsLoading] = useState(true)
-  const [runnerList, setRunnerList] = useState<ProcessedRunnerModel[]>([])
-  const [refreshTrigger, setRefreshTrigger] = useState(0) // Trigger for refresh
-
-  //fetch from back-end
-  useEffect(() => {
-    if (activeClass) {
-      getRunnersInStage(event_id, stage_id, activeClass.id).then(
-        (response) => {
-          let processRunnerList = processRunnerData(response.data)
-          processRunnerList = calculatePositionsAndBehindsFootO(processRunnerList)
-
-          setRunnerList(processRunnerList)
-          setIsLoading(false)
-        },
-        (error) => {
-          console.log(error)
-          setIsLoading(false)
-        },
-      )
-    } else {
-      setRunnerList([])
-      setIsLoading(false)
-    }
-    return () => {
-      setIsLoading(true)
-    }
-  }, [event_id, stage_id, activeClass, refreshTrigger])
-
-  // Function to trigger a refresh
-  const refresh = () => setRefreshTrigger((prev) => prev + 1)
-
-  return [runnerList, isLoading, refresh]
 }


### PR DESCRIPTION

![imagen](https://github.com/user-attachments/assets/2b38177d-84ae-4eb6-9797-0a83ffc05548)
![imagen](https://github.com/user-attachments/assets/a2c9f403-55cb-4fe8-9169-db2f485dadfb)
![imagen](https://github.com/user-attachments/assets/fda11599-2594-4c39-ae58-270092c0b993)

A new `<ClassSelector />` component has been introduced to support both **class-based** and **club-based** results views with the following key features:

## 1. Smart Search Functionality

* A **search bar** allows users to quickly look up **classes** or **clubs**.
* **Normalization**:

  * For **classes**, the search query ignores **dashes (`-`)**.
  * For **clubs**, the search query ignores both **dashes (`-`)** and **underscores (`_`)**.

##  2. Loading State Handling

* The component gracefully handles **loading states**, providing a clear user experience during asynchronous fetch operations.

## 3. URL State via `searchParams`

* The selected **class or club** is stored in the URL via `searchParams`, ensuring:

  * State persistence across reloads and navigation.
  * Shareable and bookmarkable views.
* `short_name` is used instead of ids, improving clarity in the URL and making it more human-readable.

##  4. Auto-Open Behavior

* The selector is **automatically opened** if no class or club is currently selected in the `searchParams`, helping guide first-time or lost users toward making a selection.

##  5. Virtual Ticket for Clubs

* In **club-based view** for **FootO**, all the runners in the class of the chosen runner are fetch. 
* This data is used to **compute a full virtual ticket**, enabling easier access in club-based results.

