### PR TITLE
add new types with stage logs

### DIFF
--- a/src/shared/EntityTypes.ts
+++ b/src/shared/EntityTypes.ts
@@ -70,9 +70,22 @@ export interface StageTypeModel {
     | "Trail-O"
 }
 
+export enum StateLogConst {
+  CLEAR = 0,
+  START = 1,
+  RESULT = 2,
+  ENDED = 3,
+}
+
+export interface StateLog {
+  state: StateLogConst
+  created: string
+}
+
 export interface StageModel {
   id: string
   description: string
+  last_logs: StateLog[]
   stage_type: StageTypeModel
 }
 


### PR DESCRIPTION
to provide info on when a stage was last cleared, ended or uploaded start lists or results

(useful to know if the stage has already results or start lists or if it already finished and locked with official results)



Starting with backend version 0.2.33, this information comes in stage level.

A `PATCH` to Stages endpoint `/api/v1/events/eventID/stages/stageID` (the one used for edit) can be done by sending PATCH with the json `{"state_end": true|false}`