### PR TITLE
Unify key for "disqualified" translation

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -233,7 +233,7 @@
       "dns": "DNS",
       "dnf": "DNF",
       "mp": "MP",
-      "disqualified": "DSQ",
+      "dsq": "DSQ",
       "ot": "OT"
     },
     "SplitsTable": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -227,7 +227,7 @@
       "dns": "DNS",
       "dnf": "Aban",
       "mp": "MP",
-      "disqualified": "DSQ",
+      "dsq": "DSQ",
       "ot": "FC"
     },
     "SplitsTable": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -230,7 +230,7 @@
       "dns": "DNS",
       "dnf": "DNF",
       "mp": "MP",
-      "disqualified": "DSQ",
+      "dsq": "DSQ",
       "ot": "H.Délai"
     },
     "SplitsTable": {


### PR DESCRIPTION
I have noticed a failure with the DSQ key and now is fixed