### PR TITLE
Fix/Graph selection

### DIFF
--- a/src/pages/Results/pages/Results/pages/FootO/pages/Graphs/components/CompactRunnerTable.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Graphs/components/CompactRunnerTable.tsx
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from "react-i18next"
 import { ProcessedRunnerModel } from "../../../../../../../components/VirtualTicket/shared/EntityTypes.ts"
 import { formatTime } from "../../Splits/components/utils/chartDataTransform.ts"
+import { hasChipDownload } from "../../../../../shared/functions.ts"
 
 interface CompactRunnerTableProps {
   runners: ProcessedRunnerModel[]
@@ -32,17 +33,13 @@ export default function CompactRunnerTable({
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down("md"))
 
-  const selectableRunnerIds = runners.filter((r) => r.stage.position).map((r) => r.id)
+  const selectableRunnerIds = runners
+    .filter((r) => r.stage.position && hasChipDownload(r))
+    .map((r) => r.id)
 
   useEffect(() => {
-    if (selectedRunners.length === 0 && runners.length > 0) {
-      const initialSelection = runners
-        .filter((r) => r.stage.position)
-        .slice(0, 5)
-        .map((r) => r.id)
-      onSelectionChange(initialSelection)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Note: Removed auto-refill behavior. Users can now have 0 selected runners.
+    // Initial selection is handled by the parent component (FootOSplits)
   }, [runners])
 
   const handleToggleRunner = (runnerId: string) => {
@@ -74,12 +71,14 @@ export default function CompactRunnerTable({
         <Typography variant="h6" sx={{ mb: 1 }}>
           {t("Graphs.RunnerSelection")}
         </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {t("Graphs.SelectedCount", {
-            count: selectedRunners.length,
-            total: runners.length,
-          })}
-        </Typography>
+        {selectableRunnerIds.length > 0 && (
+          <Typography variant="body2" color="text.secondary">
+            {t("Graphs.SelectedCount", {
+              count: selectedRunners.length,
+              total: selectableRunnerIds.length,
+            })}
+          </Typography>
+        )}
       </Box>
 
       <TableContainer
@@ -106,7 +105,7 @@ export default function CompactRunnerTable({
           </TableHead>
           <TableBody>
             {runners.map((runner) => {
-              const isSelectable = !!runner.stage.position
+              const isSelectable = !!runner.stage.position && hasChipDownload(runner)
               const isChecked = selectedRunners.includes(runner.id)
               return (
                 <TableRow

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
@@ -23,6 +23,8 @@ import {
 } from "./components/utils/chartDataTransform.ts"
 import { useTranslation } from "react-i18next"
 import RadiosExperimentalAlert from "../../components/RadiosExperimentalAlert.tsx"
+import { hasChipDownload } from "../../../../shared/functions.ts"
+import NoRunnerWithSplitsMsg from "./components/FootOSplitsTable/components/NoRunnerWithSplitsMsg.tsx"
 
 export default function FootOSplits(
   props: ResultsPageProps<ProcessedRunnerModel[], AxiosError<RunnerModel[]>>,
@@ -35,6 +37,9 @@ export default function FootOSplits(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const runners = props.runnersQuery.data || []
   const hasRadios = !!(activeItem && "splits" in activeItem && activeItem.splits.length > 0)
+
+  const runnersWithChipDownload = runners.filter((runner) => hasChipDownload(runner))
+  const hasChipDownloadData = runnersWithChipDownload.length > 0
 
   const displayRadiosAlert =
     props.isClass &&
@@ -68,7 +73,7 @@ export default function FootOSplits(
   useEffect(() => {
     if (runners.length > 0 && selectedRunners.length === 0) {
       const topRunners = runners
-        .filter((runner) => runner.stage.position && runner.stage.position <= 5)
+        .filter((runner) => runner.stage.position && hasChipDownload(runner))
         .sort((a, b) => (a.stage.position || 0) - (b.stage.position || 0))
         .slice(0, 5)
         .map((runner) => runner.id)
@@ -137,175 +142,184 @@ export default function FootOSplits(
   if (props.runnersQuery.isFetching) return <GeneralSuspenseFallback />
   if (props.runnersQuery.isError) return <GeneralErrorFallback />
 
-  const renderSplitsView = () => (
-    <Box>
-      <FootOSplitsTable
-        onlyRadios={false}
-        radiosList={"splits" in activeItem ? activeItem.splits : []}
-        showCumulative={showCumulative}
-        key={"FootOSplitsTable"}
-        runners={runners}
-        timeLossEnabled={false}
-        timeLossThreshold={timeLossThreshold}
-        timeLossResults={undefined}
-      />
-    </Box>
-  )
+  const renderSplitsView = () => {
+    if (!hasChipDownloadData) return <NoRunnerWithSplitsMsg />
 
-  const renderAccumulatedView = () => (
-    <Box>
-      <FootOSplitsTable
-        onlyRadios={false}
-        radiosList={"splits" in activeItem ? activeItem.splits : []}
-        showCumulative={true}
-        key={"FootOSplitsTableAccumulated"}
-        runners={runners}
-        timeLossEnabled={false}
-        timeLossThreshold={timeLossThreshold}
-        timeLossResults={undefined}
-      />
-    </Box>
-  )
-
-  const renderRadiosView = () => (
-    <Box>
-      {displayRadiosAlert ? (
-        <></>
-      ) : (
-        <Box sx={{ padding: "16px 16px 0 16px" }}>
-          <ExperimentalFeatureAlert />
-        </Box>
-      )}
-
-      <FootOSplitsTable
-        onlyRadios={true}
-        radiosList={"splits" in activeItem ? activeItem.splits : []}
-        showCumulative={showCumulative}
-        key={"FootOSplitsTableRadios"}
-        runners={runners}
-        timeLossEnabled={false}
-        timeLossThreshold={timeLossThreshold}
-        timeLossResults={undefined}
-      />
-    </Box>
-  )
-
-  const renderTimeLossView = () => (
-    <Box>
-      {displayRadiosAlert ? (
-        <></>
-      ) : (
-        <Box sx={{ padding: "16px 16px 0 16px" }}>
-          <ExperimentalFeatureAlert />
-        </Box>
-      )}
-      <Box sx={{ px: "16px", pb: "16px", display: "flex", alignItems: "center", gap: 2 }}>
-        <Typography sx={{ whiteSpace: "nowrap" }}>
-          {t("Graphs.ThresholdWithPercent", { percent: timeLossThreshold })}
-        </Typography>
-        <Slider
-          size="small"
-          value={timeLossThreshold}
-          min={5}
-          max={100}
-          step={5}
-          marks
-          onChange={(_, newValue) => {
-            if (typeof newValue === "number") {
-              setTimeLossThreshold(newValue)
-            }
-          }}
-          sx={{ flexGrow: 1, maxWidth: 300 }}
+    return (
+      <Box>
+        <FootOSplitsTable
+          onlyRadios={false}
+          radiosList={"splits" in activeItem ? activeItem.splits : []}
+          showCumulative={showCumulative}
+          key={"FootOSplitsTable"}
+          runners={runners}
+          timeLossEnabled={false}
+          timeLossThreshold={timeLossThreshold}
+          timeLossResults={undefined}
         />
       </Box>
+    )
+  }
 
-      <FootOSplitsTable
-        onlyRadios={false}
-        radiosList={"splits" in activeItem ? activeItem.splits : []}
-        showCumulative={false}
-        key={"FootOSplitsTableTimeLoss"}
-        runners={runners}
-        timeLossEnabled={true}
-        timeLossThreshold={timeLossThreshold}
-        timeLossResults={timeLossResults}
-      />
-    </Box>
-  )
+  const renderAccumulatedView = () => {
+    if (!hasChipDownloadData) return <NoRunnerWithSplitsMsg />
 
-  const renderChartView = () => (
-    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {displayRadiosAlert ? (
-        <></>
-      ) : (
-        <Box sx={{ padding: "16px 16px 0 16px" }}>
-          <ExperimentalFeatureAlert />
-        </Box>
-      )}
-      {selectedView === "barChart" && (
-        <Box sx={{ px: "16px", display: "flex", alignItems: "center", gap: 2 }}>
-          <Typography>
-            {t("Graphs.ThresholdWithPercent", { percent: barChartThreshold })}
+    return (
+      <Box>
+        <FootOSplitsTable
+          onlyRadios={false}
+          radiosList={"splits" in activeItem ? activeItem.splits : []}
+          showCumulative={true}
+          key={"FootOSplitsTableAccumulated"}
+          runners={runners}
+          timeLossEnabled={false}
+          timeLossThreshold={timeLossThreshold}
+          timeLossResults={undefined}
+        />
+      </Box>
+    )
+  }
+
+  const renderRadiosView = () => {
+    if (!hasChipDownloadData) return <NoRunnerWithSplitsMsg />
+
+    return (
+      <Box>
+        {!displayRadiosAlert && (
+          <Box sx={{ padding: "16px 16px 0 16px" }}>
+            <ExperimentalFeatureAlert />
+          </Box>
+        )}
+        <FootOSplitsTable
+          onlyRadios={true}
+          radiosList={"splits" in activeItem ? activeItem.splits : []}
+          showCumulative={showCumulative}
+          key={"FootOSplitsTableRadios"}
+          runners={runners}
+          timeLossEnabled={false}
+          timeLossThreshold={timeLossThreshold}
+          timeLossResults={undefined}
+        />
+      </Box>
+    )
+  }
+
+  const renderTimeLossView = () => {
+    if (!hasChipDownloadData) return <NoRunnerWithSplitsMsg />
+
+    return (
+      <Box>
+        {!displayRadiosAlert && (
+          <Box sx={{ padding: "16px 16px 0 16px" }}>
+            <ExperimentalFeatureAlert />
+          </Box>
+        )}
+        <Box sx={{ px: "16px", pb: "16px", display: "flex", alignItems: "center", gap: 2 }}>
+          <Typography sx={{ whiteSpace: "nowrap" }}>
+            {t("Graphs.ThresholdWithPercent", { percent: timeLossThreshold })}
           </Typography>
           <Slider
             size="small"
-            value={barChartThreshold}
+            value={timeLossThreshold}
             min={5}
             max={100}
             step={5}
             marks
             onChange={(_, newValue) => {
-              if (typeof newValue === "number") {
-                setBarChartThreshold(newValue)
-              }
+              if (typeof newValue === "number") setTimeLossThreshold(newValue)
             }}
             sx={{ flexGrow: 1, maxWidth: 300 }}
           />
         </Box>
-      )}
 
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: isMobile ? "column" : "row",
-          gap: 2,
-          flex: 1,
-          minHeight: 0,
-        }}
-      >
-        <Box sx={{ flex: 1, minHeight: 400, order: isMobile ? 2 : 1, px: 2 }}>
-          {selectedView === "lineChart" && <LineChart data={lineChartData} height={400} />}
-          {selectedView === "barChart" && <BarChart data={barChartData} height={400} />}
-          {selectedView === "positionChart" && (
-            <PositionChart data={positionChartData} height={400} />
-          )}
-        </Box>
+        <FootOSplitsTable
+          onlyRadios={false}
+          radiosList={"splits" in activeItem ? activeItem.splits : []}
+          showCumulative={false}
+          key={"FootOSplitsTableTimeLoss"}
+          runners={runners}
+          timeLossEnabled={true}
+          timeLossThreshold={timeLossThreshold}
+          timeLossResults={timeLossResults}
+        />
+      </Box>
+    )
+  }
+
+  const renderChartView = () => {
+    if (!hasChipDownloadData) return <NoRunnerWithSplitsMsg />
+
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        {!displayRadiosAlert && (
+          <Box sx={{ padding: "16px 16px 0 16px" }}>
+            <ExperimentalFeatureAlert />
+          </Box>
+        )}
+        {selectedView === "barChart" && (
+          <Box sx={{ px: "16px", display: "flex", alignItems: "center", gap: 2 }}>
+            <Typography>
+              {t("Graphs.ThresholdWithPercent", { percent: barChartThreshold })}
+            </Typography>
+            <Slider
+              size="small"
+              value={barChartThreshold}
+              min={5}
+              max={100}
+              step={5}
+              marks
+              onChange={(_, newValue) => {
+                if (typeof newValue === "number") {
+                  setBarChartThreshold(newValue)
+                }
+              }}
+              sx={{ flexGrow: 1, maxWidth: 300 }}
+            />
+          </Box>
+        )}
+
         <Box
           sx={{
-            width: isMobile ? "100%" : "auto",
-            height: 400,
-            overflowY: "auto",
-            overflowX: "hidden",
-            order: 2,
+            display: "flex",
+            flexDirection: isMobile ? "column" : "row",
+            gap: 2,
+            flex: 1,
+            minHeight: 0,
           }}
         >
-          <CompactRunnerTable
-            runners={runners}
-            selectedRunners={selectedRunners}
-            onSelectionChange={handleRunnerSelectionChange}
-          />
+          <Box sx={{ flex: 1, minHeight: 400, order: isMobile ? 2 : 1, px: 2 }}>
+            {selectedView === "lineChart" && <LineChart data={lineChartData} height={400} />}
+            {selectedView === "barChart" && <BarChart data={barChartData} height={400} />}
+            {selectedView === "positionChart" && (
+              <PositionChart data={positionChartData} height={400} />
+            )}
+          </Box>
+          <Box
+            sx={{
+              width: isMobile ? "100%" : "auto",
+              height: 400,
+              overflowY: "auto",
+              overflowX: "hidden",
+              order: 2,
+            }}
+          >
+            <CompactRunnerTable
+              runners={runners}
+              selectedRunners={selectedRunners}
+              onSelectionChange={handleRunnerSelectionChange}
+            />
+          </Box>
         </Box>
       </Box>
-    </Box>
-  )
+    )
+  }
 
   return (
     <Box>
-      {displayRadiosAlert ? (
+      {displayRadiosAlert && (
         <Box sx={{ px: "16px" }}>
           <RadiosExperimentalAlert />
         </Box>
-      ) : (
-        <></>
       )}
 
       <ViewSelector

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/utils/chartDataTransform.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/utils/chartDataTransform.ts
@@ -1,6 +1,7 @@
 import { ProcessedRunnerModel } from "../../../../../../../../components/VirtualTicket/shared/EntityTypes"
 import { ChartDataItem } from "../Charts/BarChart.tsx"
 import { getRunnerTimeLossInfo, TimeLossResults } from "./timeLossAnalysis.ts"
+import { hasChipDownload } from "../../../../../../shared/functions.ts"
 
 // Position Evolution Data Structures
 export interface PositionDataPoint {
@@ -153,7 +154,9 @@ export function transformRunnersForLineChart(
   runners: ProcessedRunnerModel[],
   selectedRunnerIds: string[],
 ): LineChartData[] {
-  const selectedRunners = runners.filter((runner) => selectedRunnerIds.includes(runner.id))
+  const selectedRunners = runners.filter(
+    (runner) => selectedRunnerIds.includes(runner.id) && hasChipDownload(runner),
+  )
   const colors = generateRunnerColors(selectedRunners.length)
 
   const leaderTimes = calculateLeaderTimesForEachControl(runners)
@@ -282,8 +285,10 @@ export function transformRunnersForPositionChart(
 ): PositionChartData[] {
   if (selectedRunnerIds.length === 0) return []
 
-  // Use all runners, don't filter by status, no limit on the number of runners
-  const selectedRunners = runners.filter((runner) => selectedRunnerIds.includes(runner.id))
+  // Filter by hasChipDownload and selectedRunnerIds
+  const selectedRunners = runners.filter(
+    (runner) => selectedRunnerIds.includes(runner.id) && hasChipDownload(runner),
+  )
   const colors = generateRunnerColors(selectedRunners.length)
 
   return selectedRunners
@@ -422,8 +427,10 @@ export function transformRunnersForBarChart(
   selectedRunnerIds: string[],
   timeLossResults?: TimeLossResults,
 ): ChartDataItem[] {
-  // Use all runners, not just "valid" ones - let each transformation decide
-  const selectedRunners = runners.filter((runner) => selectedRunnerIds.includes(runner.id))
+  // Filter by hasChipDownload and selectedRunnerIds
+  const selectedRunners = runners.filter(
+    (runner) => selectedRunnerIds.includes(runner.id) && hasChipDownload(runner),
+  )
 
   if (selectedRunners.length === 0) {
     return []


### PR DESCRIPTION
Improves the filtering and display logic for Foot-O split views by enforcing the hasChipDownload check across the board. Key changes include:

✅ Data filtering: Adds a hasChipDownload filter in all relevant chartDataTransform functions to ensure only runners with downloaded chips are included in chart data.

📊 Split views: Applies the hasChipDownload check . When no runners with valid splits are available, the NoRunnerWithSplitsMsg component is displayed.

🧮 Runner table: Updates CompactRunnerTable to filter and allow selection only of runners with downloaded chips. Removes the previous auto-selection behavior.