### PR TITLE
WORKAROUND for wrong online controls order coming from backend

### DIFF
--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/FootOSplits.tsx
@@ -41,7 +41,6 @@ export default function FootOSplits(
 
   useEffect(() => {
     sortFootORunners(runners)
-    console.log("runners sorted")
   }, [runners])
 
   const runnersWithChipDownload = runners.filter((runner) => hasChipDownload(runner))

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/FootOSplitsTable/shared/footOSplitsTableFunctions.test.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/FootOSplitsTable/shared/footOSplitsTableFunctions.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, vi, expect } from "vitest"
 import { OnlineControlModel } from "../../../../../../../../../../../shared/EntityTypes.ts"
 import {
   ProcessedSplitModel,
   RadioSplitModel,
 } from "../../../../../../../../../components/VirtualTicket/shared/EntityTypes.ts"
-import { getOnlineSplits } from "./footOSplitsTablefunctions.ts"
+import {
+  createMissingRadioFinish,
+  createMissingRadioSplit,
+  getOnlineSplits,
+} from "./footOSplitsTablefunctions.ts"
 import { DateTime } from "luxon"
 
 describe("getOnlineSplits", () => {
@@ -370,6 +374,60 @@ describe("getOnlineSplits", () => {
     const actual = getOnlineSplits(splitList, radiosList, startTime)
 
     expect(actual).toEqual(expectedOnlineControls)
+  })
+
+  it("should return all missing if the order in the splits and declared online controls does not match", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const splitList: ProcessedSplitModel[] = [
+      {
+        ...baseControl,
+        control: {
+          ...baseControl.control,
+          id: "control-41",
+          station: "41",
+        },
+        id: "41",
+        order_number: 1,
+        time: 60,
+        cumulative_time: 60,
+        reading_time: "2025-08-05T09:01:00.000+00:00",
+      },
+      {
+        ...baseControl,
+        control: {
+          ...baseControl.control,
+          id: "control-31",
+          station: "31",
+        },
+        id: "31",
+        order_number: 2,
+        time: 120,
+        cumulative_time: 180,
+        reading_time: "2025-08-05T09:03:00.000+00:00",
+      },
+      {
+        ...baseControl,
+        control: null,
+        id: "finish",
+        order_number: Infinity,
+        time: null,
+        cumulative_time: null,
+        reading_time: null,
+      },
+    ]
+
+    const expectedOnlineControls: RadioSplitModel[] = [31, 41, 51].map((station, index) =>
+      createMissingRadioSplit(station, index + 1),
+    )
+    expectedOnlineControls.push(createMissingRadioFinish())
+
+    const actual = getOnlineSplits(splitList, radiosList, startTime)
+
+    expect(actual).toEqual(expectedOnlineControls)
+    expect(consoleSpy).toHaveBeenCalled()
+
+    consoleSpy.mockClear()
   })
 
   it("should not be running towards the first online control if runner has not started", () => {

--- a/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/FootOSplitsTable/shared/footOSplitsTablefunctions.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/pages/Splits/components/FootOSplitsTable/shared/footOSplitsTablefunctions.ts
@@ -12,6 +12,7 @@ import {
 import { DateTime } from "luxon"
 import { NORMAL_CONTROL } from "../../../../../../../../../shared/constants.ts"
 import { hasChipDownload } from "../../../../../../../shared/functions.ts"
+import { captureException as sentryCaptureException, withScope } from "@sentry/react"
 
 export type CourseControlModel = {
   control: ControlModel | null
@@ -75,6 +76,56 @@ export function getOnlineControlsCourseFromClassSplits(
 }
 
 /**
+ * Helper function to create missing online controls
+ * @param station Code of the control
+ * @param orderNumber Order in which this online control is visited
+ */
+export function createMissingRadioSplit(
+  station: number | null,
+  orderNumber: number,
+): RadioSplitModel {
+  return {
+    id: `missingRadio-${station}`,
+    is_intermediate: true,
+    reading_time: null,
+    order_number: orderNumber,
+    points: 0,
+    control: station
+      ? {
+          id: `missingRadio-control-${station}`,
+          station: station.toString(),
+          control_type: NORMAL_CONTROL,
+        }
+      : null,
+    time: null,
+    time_behind: null,
+    position: null,
+    cumulative_time: null,
+    cumulative_behind: null,
+    cumulative_position: null,
+    is_next: null,
+  }
+}
+
+export function createMissingRadioFinish(): RadioSplitModel {
+  return {
+    id: `missingFinish`,
+    is_intermediate: true,
+    reading_time: null,
+    order_number: Infinity,
+    points: 0,
+    control: null,
+    time: null,
+    time_behind: null,
+    position: null,
+    cumulative_time: null,
+    cumulative_behind: null,
+    cumulative_position: null,
+    is_next: null,
+  }
+}
+
+/**
  * Get online splits from a Processed Splits list and compute the next online control
  * @param splitList List of ProcessedSplitModel to extract online controls from
  * @param radiosList List of OnlineControlModel with the online controls
@@ -96,50 +147,18 @@ export function getOnlineSplits(
 
   // Fill missing online controls from split list
   if (radioSplits.length == 0) {
-    radioSplits.push({
-      id: `missingFinish`,
-      is_intermediate: true,
-      reading_time: null,
-      order_number: Infinity,
-      points: 0,
-      control: null,
-      time: null,
-      time_behind: null,
-      position: null,
-      cumulative_time: null,
-      cumulative_behind: null,
-      cumulative_position: null,
-      is_next: null,
-    })
+    radioSplits.push(createMissingRadioFinish())
   }
   //// Regular controls
-  console.log()
   for (let i = 0; i < radiosList.length; i++) {
     const radioInRunner = radioSplits.at(i)?.control
     const radioInList = radiosList.at(i)
 
     if (radioInRunner?.station !== radioInList?.station) {
-      const missingRadio: RadioSplitModel = {
-        id: `missingRadio-${radioInList?.station}`,
-        is_intermediate: true,
-        reading_time: null,
-        order_number: i + 1,
-        points: 0,
-        control: radioInList?.station
-          ? {
-              id: `missingRadio-control-${radioInList?.station}`,
-              station: radioInList?.station,
-              control_type: NORMAL_CONTROL,
-            }
-          : null,
-        time: null,
-        time_behind: null,
-        position: null,
-        cumulative_time: null,
-        cumulative_behind: null,
-        cumulative_position: null,
-        is_next: null,
-      }
+      const missingRadio: RadioSplitModel = createMissingRadioSplit(
+        radioInList?.station ? Number(radioInList.station) : null,
+        i + 1,
+      )
 
       radioSplits.splice(i, 0, missingRadio) //insert split
     }
@@ -157,6 +176,34 @@ export function getOnlineSplits(
     } else {
       prevTimeString = split.reading_time
     }
+  }
+
+  // Error check
+  if (radioSplits.length != radiosList.length + 1) {
+    console.error(
+      "The resulting number of online controls and the number of online controls defined for this class differ",
+    )
+
+    try {
+      throw new Error(
+        "The resulting number of online controls and the number of online controls defined for this class differ",
+      )
+    } catch (error) {
+      withScope((scope) => {
+        scope.setExtra("splitList", splitList)
+        scope.setExtra("radioList", radiosList)
+        scope.setExtra("origin", "getOnlineSplits")
+
+        sentryCaptureException(error)
+      })
+    }
+
+    // Return all online controls as missing
+    const allMissingRadioSplits = radiosList.map((onlineControl, index) =>
+      createMissingRadioSplit(Number(onlineControl.station), index + 1),
+    )
+    allMissingRadioSplits.push(createMissingRadioFinish())
+    return allMissingRadioSplits
   }
 
   // Return radio splits

--- a/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
@@ -5,7 +5,9 @@ import {
   calculatePositionsAndBehindsFootO,
   processRunnerData,
 } from "../../../../../components/VirtualTicket/shared/virtualTicketFunctions.ts"
-import { StageClassModel } from "../../../../../../../shared/EntityTypes.ts"
+import { RunnerModel, StageClassModel } from "../../../../../../../shared/EntityTypes.ts"
+import { getCourseFromRunner } from "../pages/Splits/components/FootOSplitsTable/shared/footOSplitsTablefunctions.ts"
+import { captureException as sentryCaptureException } from "@sentry/react"
 
 /**
  * Query and process (compute splits) of runners by classes
@@ -28,6 +30,10 @@ export async function getFootORunnersByClass(
   const runnersPage = await getRunnersInStage(eventId, stageId, classId)
   const runnersList = sortRunners(runnersPage.data)
 
+  // TODO: WORKAROUND for bug in backed: online controls list is not sorted
+  // Use the download from any runner to get the real order of the online splits
+  wrongOnlineSplitsOrderWorkaround(classId, runnersList, classesList)
+
   // Runner processing
   const processedRunnersList = processRunnerData(runnersList, classesList)
 
@@ -49,4 +55,64 @@ export async function getFootORunnersByClub(
 
   // Processing
   return processRunnerData(runnersList, classesList)
+}
+
+/**
+ * Helper class to try fixing online splits order according to chip readings
+ * @param classId id of the class we are querying
+ * @param runnersList list of runners to read course from
+ * @param classesList list of classes we want to update
+ */
+function wrongOnlineSplitsOrderWorkaround(
+  classId: string,
+  runnersList: RunnerModel[],
+  classesList?: StageClassModel[],
+) {
+  try {
+    if (classesList && classesList.length > 0) {
+      // Find class within provided classesList
+      const thisClass = classesList.find((cls) => cls.id === classId)
+      if (thisClass && thisClass.splits.length > 0) {
+        // Get course to update runner list
+        const course = getCourseFromRunner(runnersList)
+        if (course.length > 0) {
+          const onlineControlNumbers = thisClass.splits.map((control) => control.station)
+
+          // Find controls that are online controls and pick their order
+          const filteredCourse = course.filter(
+            (control) => control.control && onlineControlNumbers.includes(control.control.station),
+          )
+          const sortedOnlineControls = filteredCourse.map((control) => {
+            const match = thisClass.splits.find(
+              (onlineControl) => onlineControl.station === control.control?.station,
+            )
+
+            if (!match) {
+              throw new Error(
+                "Algorithm to update online splits based on chip reading produced undefined splits",
+              )
+            }
+
+            return match
+          })
+
+          // Final check
+          if (sortedOnlineControls.length != thisClass.splits.length) {
+            throw new Error(
+              "Algorithm to update online splits based on chip reading failed to produce the same number of splits",
+            )
+          }
+
+          // Update online controls
+          console.debug("Online controls order updated through chip readings")
+          thisClass.splits = sortedOnlineControls
+        }
+      } else {
+        console.debug("Online controls order not updated because no chip readings were founds")
+      }
+    }
+  } catch (error) {
+    console.error(error)
+    sentryCaptureException(error)
+  }
 }

--- a/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
+++ b/src/pages/Results/pages/Results/pages/FootO/services/FootOService.ts
@@ -106,9 +106,9 @@ function wrongOnlineSplitsOrderWorkaround(
           // Update online controls
           console.debug("Online controls order updated through chip readings")
           thisClass.splits = sortedOnlineControls
+        } else {
+          console.debug("Online controls order not updated because no chip readings were founds")
         }
-      } else {
-        console.debug("Online controls order not updated because no chip readings were founds")
       }
     }
   } catch (error) {


### PR DESCRIPTION
Two main changes are introduced:
 - Handle when the algorithm to extract online controls fails, returning no data instead of wrong data
 - If a class has at least one right chip reading, the course is read form that chip reading. Then, the order from the course is used as the order of the online splits