### PR TITLE
Automatically handle `Failed to fetch dynamically imported module`

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -143,6 +143,10 @@
   },
   "Events": "Events",
   "ExperimentalFeatureMsg": "Experimental feature",
+  "FailedToLoad": {
+    "msg": "Please check your internet connection. If the error persists, try again later.",
+    "title": "Page loading failed"
+  },
   "FieldTooLongMsg": "Maximum {{count}} characters allowed.",
   "ForbiddenAccess": "Forbidden access",
   "GeneralErrorFallback": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from "react"
+import { Suspense, useEffect, useState } from "react"
 import { ThemeProvider, createTheme } from "@mui/material"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 import { AdapterLuxon } from "@mui/x-date-pickers/AdapterLuxon"
@@ -7,38 +7,45 @@ import { LocalizationProvider } from "@mui/x-date-pickers"
 import GeneralSuspenseFallback from "./components/GeneralSuspenseFallback.tsx"
 import Layout from "./components/layout/Layout.tsx"
 import { NotificationsProvider } from "@toolpad/core"
+import { lazyWithRetry } from "./services/lazyLoad.ts"
 import { useTranslation } from "react-i18next"
 import { Settings as LuxonSettings } from "luxon"
 import CountriesLocalizationProvider from "./services/countryService/countriesProvider.tsx"
 
-const EventsList = lazy(() => import("./pages/Results/pages/EventList/EventsList.tsx"))
-const EventDetail = lazy(() => import("./pages/Results/pages/EventDetail/EventDetail.tsx"))
-const Dashboard = lazy(() => import("./pages/Administration/pages/Dashboard/Dashboard.tsx"))
-const CreateEvent = lazy(
+const EventsList = lazyWithRetry(() => import("./pages/Results/pages/EventList/EventsList.tsx"))
+const EventDetail = lazyWithRetry(() => import("./pages/Results/pages/EventDetail/EventDetail.tsx"))
+const Dashboard = lazyWithRetry(
+  () => import("./pages/Administration/pages/Dashboard/Dashboard.tsx"),
+)
+const CreateEvent = lazyWithRetry(
   () => import("./pages/Administration/pages/EventAdmin/pages/CreateEvent/CreateEvent.tsx"),
 )
-const InItSignIn = lazy(
+const InItSignIn = lazyWithRetry(
   () => import("./pages/Administration/pages/Authentication/pages/InItSignIn.tsx"),
 )
-const SignIn = lazy(() => import("./pages/Administration/pages/Authentication/pages/SignIn.tsx"))
-const SignUp = lazy(() => import("./pages/Administration/pages/Authentication/pages/SignUp"))
-const Authentication = lazy(
+const SignIn = lazyWithRetry(
+  () => import("./pages/Administration/pages/Authentication/pages/SignIn.tsx"),
+)
+const SignUp = lazyWithRetry(
+  () => import("./pages/Administration/pages/Authentication/pages/SignUp"),
+)
+const Authentication = lazyWithRetry(
   () => import("./pages/Administration/pages/Authentication/pages/Authentication.tsx"),
 )
-const PrivateRoute = lazy(
+const PrivateRoute = lazyWithRetry(
   () => import("./pages/Administration/pages/Authentication/components/PrivateRoute.tsx"),
 )
-const EventAdmin = lazy(
+const EventAdmin = lazyWithRetry(
   () => import("./pages/Administration/pages/EventAdmin/pages/EventAdmin/EventAdmin.tsx"),
 )
-const Results = lazy(() => import("./pages/Results/pages/Results/Results.tsx"))
-const AboutUs = lazy(() => import("./pages/AboutUs/AboutUs.tsx"))
-const NotFoundPage = lazy(() => import("./pages/NotFoundError/NotFoundPage.tsx"))
-const Organizers = lazy(() => import("./pages/Organizers/organizers.tsx"))
-const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy/PrivacyPolicy.tsx"))
-const CookiesPolicy = lazy(() => import("./pages/CookiesPolicy/CookiesPolicy.tsx"))
-const LegalNotice = lazy(() => import("./pages/LegalNotice/LegalNotice.tsx"))
-const MyAccount = lazy(() => import("./pages/Administration/pages/MyAccount/index.tsx"))
+const Results = lazyWithRetry(() => import("./pages/Results/pages/Results/Results.tsx"))
+const AboutUs = lazyWithRetry(() => import("./pages/AboutUs/AboutUs.tsx"))
+const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundError/NotFoundPage.tsx"))
+const Organizers = lazyWithRetry(() => import("./pages/Organizers/organizers.tsx"))
+const PrivacyPolicy = lazyWithRetry(() => import("./pages/PrivacyPolicy/PrivacyPolicy.tsx"))
+const CookiesPolicy = lazyWithRetry(() => import("./pages/CookiesPolicy/CookiesPolicy.tsx"))
+const LegalNotice = lazyWithRetry(() => import("./pages/LegalNotice/LegalNotice.tsx"))
+const MyAccount = lazyWithRetry(() => import("./pages/Administration/pages/MyAccount/index.tsx"))
 
 // Customize style of app
 const theme = createTheme({

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react"
 import type { ErrorBoundaryProps, FallbackRender } from "@sentry/react"
 import GeneralErrorFallback from "../GeneralErrorFallback.tsx"
 import { ChunkLoadError } from "../../services/lazyLoad.ts"
+import FailedToLoadAlert from "./components/FailToLoadAlert/FaildToLoadAlert.tsx"
 
 interface Props extends ErrorBoundaryProps {
   displayMsg?: boolean
@@ -101,10 +102,13 @@ class ErrorBoundary extends Sentry.ErrorBoundary {
   }
 
   render(): ReactNode {
-    const { hasError } = this.state
+    const { hasError, error } = this.state
     const { displayMsg, children } = this.props
 
     if (hasError) {
+      if (error instanceof ChunkLoadError) {
+        return <FailedToLoadAlert />
+      }
       return <GeneralErrorFallback displayMsg={displayMsg} />
     }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from "react"
+import * as Sentry from "@sentry/react"
+import type { ErrorBoundaryProps, FallbackRender } from "@sentry/react"
+import GeneralErrorFallback from "../GeneralErrorFallback.tsx"
+import { ChunkLoadError } from "../../services/lazyLoad.ts"
+
+interface Props extends ErrorBoundaryProps {
+  displayMsg?: boolean
+}
+
+type SentryState = InstanceType<typeof Sentry.ErrorBoundary>["state"]
+
+type State =
+  | (Extract<SentryState, { error: null }> & { hasError: false })
+  | (Extract<SentryState, { error: unknown }> & { hasError: true })
+
+const SESSION_STORAGE_KEY = "chunk_reload_attempted"
+
+const INITIAL_STATE: State = {
+  hasError: false,
+  componentStack: null,
+  error: null,
+  eventId: null,
+}
+
+/**
+ * An error boundary that extends Sentry's `ErrorBoundary` with automatic chunk error recovery.
+ *
+ * Handles two categories of errors:
+ * - **Chunk load errors** (`ChunkLoadError` or dynamic import failures) — automatically attempts
+ *   a one-time page reload to recover. If the error persists after reload, falls back to
+ *   `GeneralErrorFallback`. The reload attempt is tracked in `sessionStorage` to prevent
+ *   infinite reload loops.
+ * - **All other errors** — captured and reported to Sentry via `super.componentDidCatch`,
+ *   then renders `GeneralErrorFallback`.
+ *
+ * @extends {Sentry.ErrorBoundary}
+ *
+ * @example
+ * // Basic usage — wraps a route outlet, shows fallback on error
+ * <ErrorBoundary>
+ *   <Outlet />
+ * </ErrorBoundary>
+ *
+ * @example
+ * // With displayMsg — shows a user-facing error message in the fallback
+ * <ErrorBoundary displayMsg>
+ *   <Outlet />
+ * </ErrorBoundary>
+ *
+ * @example
+ * // With Sentry's beforeCapture — attach extra context to the Sentry event
+ * <ErrorBoundary
+ *   displayMsg
+ *   beforeCapture={(scope) => {
+ *     scope.setTag("section", "dashboard")
+ *   }}
+ * >
+ *   <Outlet />
+ * </ErrorBoundary>
+ *
+ * @example
+ * // With onError — side effects when an error is caught
+ * <ErrorBoundary onError={(error) => analytics.track("error", { error })}>
+ *   <Outlet />
+ * </ErrorBoundary>
+ */
+class ErrorBoundary extends Sentry.ErrorBoundary {
+  declare props: Props
+  state: State = INITIAL_STATE
+
+  static getDerivedStateFromError(error: Error): State {
+    const isChunkLoadError = error instanceof ChunkLoadError
+
+    if (isChunkLoadError) {
+      console.debug("Chunk error caught while fetching dynamically imported module")
+      const hasReloaded = sessionStorage.getItem(SESSION_STORAGE_KEY) === "true"
+
+      if (!hasReloaded) {
+        console.debug("Triggering page reload from chunk reload")
+        sessionStorage.setItem(SESSION_STORAGE_KEY, "true")
+        window.location.reload()
+
+        return INITIAL_STATE
+      }
+    }
+
+    return {
+      hasError: true,
+      componentStack: null,
+      error,
+      eventId: "",
+    }
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State): void {
+    super.componentDidUpdate?.(prevProps, prevState)
+    if (prevState.hasError && !this.state.hasError) {
+      sessionStorage.removeItem(SESSION_STORAGE_KEY)
+    }
+  }
+
+  render(): ReactNode {
+    const { hasError } = this.state
+    const { displayMsg, children } = this.props
+
+    if (hasError) {
+      return <GeneralErrorFallback displayMsg={displayMsg} />
+    }
+
+    if (typeof children === "function") {
+      return (children as FallbackRender)({
+        error: this.state.error,
+        componentStack: this.state.componentStack ?? "",
+        eventId: this.state.eventId ?? "",
+        resetError: () => this.setState(INITIAL_STATE),
+      })
+    }
+
+    return children
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/ErrorBoundary/components/FailToLoadAlert/FaildToLoadAlert.tsx
+++ b/src/components/ErrorBoundary/components/FailToLoadAlert/FaildToLoadAlert.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next"
+import { Alert, AlertTitle } from "@mui/material"
+
+export default function FailedToLoadAlert() {
+  const { t } = useTranslation()
+
+  return (
+    <Alert
+      severity="error"
+      sx={{
+        height: "100%",
+        margin: 2,
+      }}
+      variant={"outlined"}
+    >
+      <AlertTitle>{t("FailedToLoad.title")}</AlertTitle>
+      {t("FailedToLoad.msg")}
+    </Alert>
+  )
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -5,9 +5,8 @@ import { Suspense, useEffect, useState } from "react"
 import Sidebar from "./Sidebar/Sidebar.tsx"
 import { useTranslation } from "react-i18next"
 import GeneralSuspenseFallback from "../GeneralSuspenseFallback.tsx"
-import { ErrorBoundary } from "@sentry/react"
-import GeneralErrorFallback from "../GeneralErrorFallback.tsx"
 import { useNotifications } from "@toolpad/core/useNotifications"
+import ErrorBoundary from "../ErrorBoundary/ErrorBoundary.tsx"
 const VERSION_NUMBER = import.meta.env.VITE_VERSION_NUMBER
 const VERSION_TYPE = import.meta.env.VITE_VERSION_TYPE
 
@@ -31,7 +30,7 @@ export default function Layout() {
       <Sidebar key={"AppSidebar"} openSidebar={isSideBarOpen} setOpenSidebar={setIsSideBarOpen} />
 
       <Suspense fallback={<GeneralSuspenseFallback />} key={location.pathname}>
-        <ErrorBoundary key={"MainErrorBoundary"} fallback={<GeneralErrorFallback displayMsg />}>
+        <ErrorBoundary key={"MainErrorBoundary"} displayMsg>
           <Outlet />
         </ErrorBoundary>
       </Suspense>

--- a/src/pages/Results/pages/Results/Results.tsx
+++ b/src/pages/Results/pages/Results/Results.tsx
@@ -3,13 +3,13 @@ import { useFetchEventDetail } from "../../services/FetchHooks.ts"
 import GeneralSuspenseFallback from "../../../../components/GeneralSuspenseFallback.tsx"
 import NotFoundPage from "../../../NotFoundError/NotFoundPage.tsx"
 import GeneralErrorFallback from "../../../../components/GeneralErrorFallback.tsx"
-import { ErrorBoundary } from "@sentry/react"
 import EventStageBanner from "./components/EventStageBanner.tsx"
 import StageTypeSelector from "./components/StageTypeSelector.tsx"
 import { Suspense } from "react"
 import { useTranslation } from "react-i18next"
 import { STAGE_TYPE_DATABASE_ID } from "./shared/constants.ts"
 import PrivateEventPage from "../../../PrivateEventError"
+import ErrorBoundary from "../../../../components/ErrorBoundary/ErrorBoundary.tsx"
 import { useQuery } from "react-query"
 import { getClassesInStage } from "../../services/EventService.ts"
 import NoDataInStageMsg from "./components/NoDataInStageMsg.tsx"
@@ -67,7 +67,7 @@ export default function Results() {
   // Component
   return (
     <Suspense fallback={<GeneralSuspenseFallback />}>
-      <ErrorBoundary fallback={<GeneralErrorFallback />}>
+      <ErrorBoundary>
         <EventStageBanner
           key={`StageBanner${eventDetail.id}`}
           eventName={eventDetail.description}

--- a/src/pages/Results/pages/Results/components/Layout/StageLayout.tsx
+++ b/src/pages/Results/pages/Results/components/Layout/StageLayout.tsx
@@ -5,11 +5,9 @@ import RefreshIcon from "@mui/icons-material/Refresh"
 import { useTranslation } from "react-i18next"
 import { ClassModel, ClubModel, Page } from "../../../../../../shared/EntityTypes.ts"
 import React from "react"
-import { ErrorBoundary } from "@sentry/react"
-import GeneralErrorFallback from "../../../../../../components/GeneralErrorFallback.tsx"
-//import NoDataInStageMsg from "../NoDataInStageMsg.tsx"
 import WrongResultsFileUploadedMsg from "../WrongResultsFileUploadedMsg.tsx"
 import { UseQueryResult } from "react-query"
+import ErrorBoundary from "../../../../../../components/ErrorBoundary/ErrorBoundary.tsx"
 import TimezoneMsg from "./components/TimezoneMsg.tsx"
 
 type StageLayoutProps = {
@@ -67,9 +65,7 @@ export default function StageLayout(props: StageLayoutProps) {
       </Box>
       {props.displayTimezoneMsg ? <TimezoneMsg /> : null}
       <Box sx={{ marginTop: "12px", flex: 1, paddingBottom: "56px" }}>
-        <ErrorBoundary fallback={<GeneralErrorFallback displayMsg />}>
-          {props.children}
-        </ErrorBoundary>
+        <ErrorBoundary displayMsg>{props.children}</ErrorBoundary>
       </Box>
     </Box>
   )

--- a/src/pages/Results/pages/Results/components/ResultTabs.tsx
+++ b/src/pages/Results/pages/Results/components/ResultTabs.tsx
@@ -1,8 +1,7 @@
 import { useSelectedMenu } from "../../../shared/hooks.ts"
 import { BottomNavigation, Paper } from "@mui/material"
 import React from "react"
-import { ErrorBoundary } from "@sentry/react"
-import GeneralErrorFallback from "../../../../../components/GeneralErrorFallback.tsx"
+import ErrorBoundary from "../../../../../components/ErrorBoundary/ErrorBoundary.tsx"
 
 type ResultTabsProps = {
   children: React.ReactNode[]
@@ -27,9 +26,7 @@ export default function ResultTabs(props: ResultTabsProps) {
 
   return (
     <>
-      <ErrorBoundary fallback={<GeneralErrorFallback />}>
-        {props.children[selectedMenu]}
-      </ErrorBoundary>
+      <ErrorBoundary>{props.children[selectedMenu]}</ErrorBoundary>
       <Paper sx={{ position: "fixed", bottom: 0, right: 0, left: 0, zIndex: 999 }}>
         <BottomNavigation
           showLabels

--- a/src/pages/Results/pages/Results/components/StageTypeSelector.tsx
+++ b/src/pages/Results/pages/Results/components/StageTypeSelector.tsx
@@ -1,11 +1,11 @@
 import { STAGE_TYPE_DATABASE_ID } from "../shared/constants.ts"
-import { lazy } from "react"
-const Ranking = lazy(() => import("../pages/Ranking"))
-const OneManRelay = lazy(() => import("../pages/OneManRelay"))
-const FootO = lazy(() => import("../pages/FootO/FootO.tsx"))
-const Relay = lazy(() => import("../pages/Relay/Relay.tsx"))
-const Rogaine = lazy(() => import("../pages/Rogaine/Rogaine.tsx"))
-const Totals = lazy(() => import("../pages/Totals/Totals.tsx"))
+import { lazyWithRetry } from "../../../../../services/lazyLoad.ts"
+const Ranking = lazyWithRetry(() => import("../pages/Ranking"))
+const OneManRelay = lazyWithRetry(() => import("../pages/OneManRelay"))
+const FootO = lazyWithRetry(() => import("../pages/FootO/FootO.tsx"))
+const Relay = lazyWithRetry(() => import("../pages/Relay/Relay.tsx"))
+const Rogaine = lazyWithRetry(() => import("../pages/Rogaine/Rogaine.tsx"))
+const Totals = lazyWithRetry(() => import("../pages/Totals/Totals.tsx"))
 
 type StageTypeSelectorProps = {
   stageType: string

--- a/src/services/lazyLoad.ts
+++ b/src/services/lazyLoad.ts
@@ -1,0 +1,120 @@
+import type { LazyExoticComponent, ComponentType } from "react"
+import { lazy } from "react"
+
+/**
+ * Error thrown when a dynamic import fails after all retry attempts.
+ *
+ * Extends the native `Error` with a `url` field extracted from the browser's
+ * error message, which contains the full URL of the chunk that failed to load.
+ * This allows {@link ErrorBoundary} to identify chunk load failures across all
+ * major browsers via `instanceof ChunkLoadError` rather than brittle message
+ * string matching.
+ *
+ * @extends {Error}
+ *
+ * @example
+ * // Checking for chunk errors in a catch block
+ * try {
+ *   await import("./Dashboard")
+ * } catch (error) {
+ *   if (error instanceof ChunkLoadError) {
+ *     console.error("Chunk failed to load:", error.url)
+ *   }
+ * }
+ *
+ * @example
+ * // Narrowing in ErrorBoundary
+ * const isChunkLoadError = (error: Error): boolean =>
+ *   error instanceof ChunkLoadError ||
+ *   error.name === "ChunkLoadError" // fallback for browser-native chunk errors
+ */
+export class ChunkLoadError extends Error {
+  readonly url: string
+
+  constructor(url: string, cause?: unknown) {
+    super(`Failed to load chunk: ${url}`)
+    this.name = "ChunkLoadError"
+    this.url = url
+    this.cause = cause
+  }
+}
+
+/**
+ * Attempts a dynamic import, retrying once after a delay if the initial attempt fails.
+ *
+ * Intended to be used exclusively via {@link lazyWithRetry} — not called directly.
+ * If both attempts fail, throws a {@link ChunkLoadError} with the browser's native
+ * error message attached as `cause`, preserving the original error for Sentry reporting
+ * and debugging.
+ *
+ * @param importFn - A function that returns a dynamic import promise
+ * @param retries - Number of retry attempts remaining (default: 1)
+ * @param retryDelay - Milliseconds to wait before retrying (default: 500)
+ *
+ * @returns The resolved module containing the default export
+ *
+ * @throws {ChunkLoadError} If the import fails after all retries are exhausted
+ *
+ * @example
+ * // Resolves on first attempt
+ * const module = await importWithRetry(() => import("./Dashboard"))
+ *
+ * @example
+ * // Retries once after 500ms, then throws ChunkLoadError
+ * const module = await importWithRetry(() => import("./Dashboard"), 1, 500)
+ */
+const importWithRetry = async <T extends ComponentType<unknown>>(
+  importFn: () => Promise<{ default: T }>,
+  retries = 1,
+  retryDelay = 500,
+): Promise<{ default: T }> => {
+  try {
+    return await importFn()
+  } catch (error) {
+    if (retries <= 0) {
+      const url = error instanceof Error ? error.message : String(error)
+      throw new ChunkLoadError(url, error)
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, retryDelay))
+    return importWithRetry(importFn, retries - 1, retryDelay)
+  }
+}
+
+/**
+ * A wrapper around React's `lazy` that automatically retries a failed dynamic import
+ * once before throwing a {@link ChunkLoadError}.
+ *
+ * On the first failure, waits 500ms then retries the import. If the retry also fails,
+ * throws a `ChunkLoadError` with the browser's native error message (which includes
+ * the chunk URL) attached as `cause`. This error is then caught by `ErrorBoundary`,
+ * which attempts a one-time page reload before showing the fallback UI.
+ *
+ * @param importFn - A function that returns a dynamic import promise, identical to
+ * what you would pass to `React.lazy`
+ *
+ * @returns A lazy-loaded React component with automatic retry behaviour
+ *
+ * @throws {ChunkLoadError} If the import fails after one retry
+ *
+ * @example
+ * // Basic usage — drop-in replacement for React.lazy
+ * const Dashboard = lazyWithRetry(() => import("./Dashboard"))
+ *
+ * @example
+ * // Used with Suspense and ErrorBoundary
+ * const Settings = lazyWithRetry(() => import("./Settings"))
+ *
+ * function App() {
+ *   return (
+ *     <ErrorBoundary>
+ *       <Suspense fallback={<Spinner />}>
+ *         <Settings />
+ *       </Suspense>
+ *     </ErrorBoundary>
+ *   )
+ * }
+ */
+export const lazyWithRetry = <T extends ComponentType<unknown>>(
+  importFn: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> => lazy(() => importWithRetry(importFn))


### PR DESCRIPTION
On every deploy the assets change. However, some clients may still reference the old file in their `index.html`. In that case, dynamically imported assets fail to load. Now, those this failure is caught throw a custom  `ChunkLoadError` at a brand new `ErrorBoundary`. Reloading the page fixes this issue.

When the failure is encountered, a page reload is trigger. If the error persist after reloading, a custom error message is triggered: "Please check your internet connection. If the error persists, try again later."